### PR TITLE
#12: Warn users during a status run of containers no longer attached to pygmy which are still running.

### DIFF
--- a/service/library/status.go
+++ b/service/library/status.go
@@ -23,6 +23,19 @@ func Status(c Config) {
 		}
 	}
 
+	{
+		Containers, _ := model.DockerContainerList()
+		for _, Container := range Containers {
+			if Container.State == "running" {
+				if e := c.Services[fmt.Sprint(Container.Names)]; e.Name == "" {
+					if f := Container.Labels["pygmy"]; f == "pygmy" {
+						fmt.Printf("[!] %v: Still running as container %v\n", Container.Image, Container.Names[0])
+					}
+				}
+			}
+		}
+	}
+
 	for Network, Containers := range c.Networks {
 		netStat, _ := network.Status(Network)
 		if netStat {


### PR DESCRIPTION
Resolves #12 

Simply adds some messages for configured pygmy containers still running which have since been removed from configuration. These containers are identified by the `pygmy` label which aren't in configuration.