### PR TITLE
Fixes for #25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-builds/pygmy-go-*
+builds/*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and then test the OSX version.
 
 1. `git clone https://github.com/fubarhouse/pygmy-go.git && cd pygmy-go`
 2. `make build`
-3. `cp ./builds/pygmy-go-darwin /usr/local/bin/pygmy-go && chmod -x /usr/local/bin/pygmy-go`
+3. `cp ./builds/pygmy-go-darwin /usr/local/bin/pygmy-go && chmod +x /usr/local/bin/pygmy-go`
 
 Pygmy is now an executable as `pygmy-go`, while any existing Pygmy is still executable
 as `pygmy`. Now start Pygmy and use the new `status` command.

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -151,19 +151,20 @@ func (Service *Service) Clean() error {
 	Containers, _ := DockerContainerList()
 	for _, container := range Containers {
 		if container.Labels["pygmy"] == "pygmy" {
+			name := strings.TrimLeft(container.Names[0], "/")
 			if e := DockerKill(container.ID); e == nil {
 				if !Service.HostConfig.AutoRemove {
-					fmt.Printf("Successfully killed %v\n", container.Names[0])
+					fmt.Printf("Successfully killed %v\n", name)
 				}
 			}
 			if e := DockerStop(container.ID); e == nil {
 				if !Service.HostConfig.AutoRemove {
-					fmt.Printf("Successfully stopped %v\n", container.Names[0])
+					fmt.Printf("Successfully stopped %v\n", name)
 				}
 			}
 			if e := DockerRemove(container.ID); e != nil {
 				if !Service.HostConfig.AutoRemove {
-					fmt.Printf("Successfully removed %v\n", container.Names[0])
+					fmt.Printf("Successfully removed %v\n", name)
 				}
 			}
 		}
@@ -189,7 +190,8 @@ func (Service *Service) Stop() error {
 		if e := DockerStop(container.ID); e == nil {
 			if e := DockerRemove(container.ID); e == nil {
 				if !Service.Discrete {
-					fmt.Printf("Successfully removed %v\n", name)
+					containerName := strings.TrimLeft(name, "/")
+					fmt.Printf("Successfully removed %v\n", containerName)
 				}
 			}
 		}

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -147,22 +147,24 @@ func (Service *Service) Clean() error {
 	if Service.Name == "" {
 		return nil
 	}
-	names := []string{"/" + Service.Name, Service.Name}
 
-	for _, name := range names {
-		if e := DockerKill(name); e == nil {
-			if !Service.HostConfig.AutoRemove {
-				fmt.Printf("Successfully killed %v\n", name)
+	Containers, _ := DockerContainerList()
+	for _, container := range Containers {
+		if container.Labels["pygmy"] == "pygmy" {
+			if e := DockerKill(container.ID); e == nil {
+				if !Service.HostConfig.AutoRemove {
+					fmt.Printf("Successfully killed %v\n", container.Names[0])
+				}
 			}
-		}
-		if e := DockerStop(name); e == nil {
-			if !Service.HostConfig.AutoRemove {
-				fmt.Printf("Successfully stopped %v\n", name)
+			if e := DockerStop(container.ID); e == nil {
+				if !Service.HostConfig.AutoRemove {
+					fmt.Printf("Successfully stopped %v\n", container.Names[0])
+				}
 			}
-		}
-		if e := DockerRemove(name); e != nil {
-			if !Service.HostConfig.AutoRemove {
-				fmt.Printf("Successfully removed %v\n", name)
+			if e := DockerRemove(container.ID); e != nil {
+				if !Service.HostConfig.AutoRemove {
+					fmt.Printf("Successfully removed %v\n", container.Names[0])
+				}
 			}
 		}
 	}
@@ -364,13 +366,13 @@ func DockerKill(name string) error {
 	return nil
 }
 
-func DockerRemove(name string) error {
+func DockerRemove(id string) error {
 	ctx := context.Background()
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return err
 	}
-	err = cli.ContainerRemove(ctx, name, types.ContainerRemoveOptions{})
+	err = cli.ContainerRemove(ctx, id, types.ContainerRemoveOptions{})
 	if err != nil {
 		return err
 	}

--- a/service/library/dryrun.go
+++ b/service/library/dryrun.go
@@ -16,23 +16,29 @@ func DryRun(c *Config) []CompatibilityCheck {
 	messages := []CompatibilityCheck{}
 
 	for _, Service := range c.Services {
-		if s, _ := Service.Status(); !s {
-			for PortBinding, Ports := range Service.HostConfig.PortBindings {
-				if strings.Contains(string(PortBinding), "tcp") {
-					for _, Port := range Ports {
-						p := fmt.Sprint(Port.HostPort)
-						conn, err := net.Listen("tcp", ":"+p)
-						conn.Close()
-						if err != nil {
-							messages = append(messages, CompatibilityCheck{
-								State:   false,
-								Message: fmt.Sprintf("[ ] %v is not able to start on port %v: already in use", Service.Name, p),
-							})
-						} else {
-							messages = append(messages, CompatibilityCheck{
-								State:   true,
-								Message: fmt.Sprintf("[*] %v is able to start on port %v", Service.Name, p),
-							})
+		if !Service.Disabled {
+			if s, _ := Service.Status(); !s {
+				for PortBinding, Ports := range Service.HostConfig.PortBindings {
+					if strings.Contains(string(PortBinding), "tcp") {
+						for _, Port := range Ports {
+							p := fmt.Sprint(Port.HostPort)
+							conn, err := net.Listen("tcp", ":"+p)
+							if conn != nil {
+								if e := conn.Close(); e != nil {
+									fmt.Println(e)
+								}
+							}
+							if err != nil {
+								messages = append(messages, CompatibilityCheck{
+									State:   false,
+									Message: fmt.Sprintf("[ ] %v is not able to start on port %v: already in use", Service.Name, p),
+								})
+							} else {
+								messages = append(messages, CompatibilityCheck{
+									State:   true,
+									Message: fmt.Sprintf("[*] %v is able to start on port %v", Service.Name, p),
+								})
+							}
 						}
 					}
 				}

--- a/service/library/dryrun.go
+++ b/service/library/dryrun.go
@@ -21,7 +21,8 @@ func DryRun(c *Config) []CompatibilityCheck {
 				if strings.Contains(string(PortBinding), "tcp") {
 					for _, Port := range Ports {
 						p := fmt.Sprint(Port.HostPort)
-						_, err := net.Listen("tcp", ":"+p)
+						conn, err := net.Listen("tcp", ":"+p)
+						conn.Close()
 						if err != nil {
 							messages = append(messages, CompatibilityCheck{
 								State:   false,

--- a/service/library/dryrun.go
+++ b/service/library/dryrun.go
@@ -1,0 +1,43 @@
+package library
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+type CompatibilityCheck struct {
+	State   bool   `yaml:"value"`
+	Message string `yaml:"string"`
+}
+
+func DryRun(c *Config) []CompatibilityCheck {
+
+	messages := []CompatibilityCheck{}
+
+	for _, Service := range c.Services {
+		if s, _ := Service.Status(); !s {
+			for PortBinding, Ports := range Service.HostConfig.PortBindings {
+				if strings.Contains(string(PortBinding), "tcp") {
+					for _, Port := range Ports {
+						p := fmt.Sprint(Port.HostPort)
+						_, err := net.Listen("tcp", ":"+p)
+						if err != nil {
+							messages = append(messages, CompatibilityCheck{
+								State:   false,
+								Message: fmt.Sprintf("[ ] %v is not able to start on port %v: already in use", Service.Name, p),
+							})
+						} else {
+							messages = append(messages, CompatibilityCheck{
+								State:   true,
+								Message: fmt.Sprintf("[*] %v is able to start on port %v", Service.Name, p),
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return messages
+}

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -15,7 +15,7 @@ func Status(c Config) {
 	Setup(&c)
 	checks := DryRun(&c)
 
-	if checks != nil {
+	if len(checks) > 0 {
 		fmt.Println("Port allocation issue(s) were identified:")
 		for _, check := range checks {
 			fmt.Println(check.Message)

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -15,8 +15,12 @@ func Status(c Config) {
 	Setup(&c)
 	checks := DryRun(&c)
 
-	for _, check := range checks {
-		fmt.Println(check.Message)
+	if checks != nil {
+		fmt.Println("Port allocation issue(s) were identified:")
+		for _, check := range checks {
+			fmt.Println(check.Message)
+		}
+		fmt.Println()
 	}
 
 	// Logic for containers when containers are running.

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -13,7 +13,13 @@ import (
 func Status(c Config) {
 
 	Setup(&c)
+	checks := DryRun(&c)
 
+	for _, check := range checks {
+		fmt.Println(check.Message)
+	}
+
+	// Logic for containers when containers are running.
 	Containers, _ := model.DockerContainerList()
 	for _, Container := range Containers {
 		if Container.Labels["pygmy"] == "pygmy" {
@@ -35,6 +41,13 @@ func Status(c Config) {
 			} else {
 				fmt.Printf("[!] %v: Still running as (no longer configured)\n", name)
 			}
+		}
+	}
+
+	// Logic for containers when they're not running.
+	for _, Container := range c.Services {
+		if s, _ := Container.Status(); !s {
+			fmt.Printf("[ ] %v is not running\n", Container.Name)
 		}
 	}
 

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -1,6 +1,8 @@
 package library
 
 import (
+	"os"
+
 	"fmt"
 	"github.com/fubarhouse/pygmy/v1/service/haproxy_connector"
 	model "github.com/fubarhouse/pygmy/v1/service/interface"
@@ -11,6 +13,19 @@ import (
 func Up(c Config) {
 
 	Setup(&c)
+	checks := DryRun(&c)
+
+	foundIssues := 0
+	for _, check := range checks {
+		if !check.State {
+			fmt.Println(check.Message)
+			foundIssues++
+		}
+	}
+	if foundIssues > 0 {
+		fmt.Println("Please address the above issues before you attempt to start Pygmy again.")
+		os.Exit(1)
+	}
 
 	for _, volume := range c.Volumes {
 		if s, _ := model.DockerVolumeExists(volume); !s {

--- a/service/resolv/resolv.go
+++ b/service/resolv/resolv.go
@@ -153,9 +153,7 @@ func (resolv Resolv) Clean() {
 				if err != nil {
 					fmt.Println(err)
 				}
-				if err = os.Remove(fullPath); err != nil {
-					fmt.Println(err)
-				} else {
+				if !resolv.statusFile() {
 					fmt.Println("Successfully removed resolver file")
 				}
 			}


### PR DESCRIPTION
Resolves #25 

A series of changes to stability and cleanup, also adds port checking and validation prior to launching containers. Multiple changes have been rolled into this change, and a full list of changes are listed below:

- `.gitignore` is fixed for `/builds/*`
- `README.md` fix for instructions where `chmod` requirements were inverted
- `README.md` spelling mistake correction
- Changes which allow for proper name-agnostic container removal
- Container removal output has changed to be more familiar
- Duplication of resolver file removals (a feature exclusive to Darwin) has been removed in favor of a file state check which already exists.
- A new command-like file labelled as `DryRun` allows for port mapping checks to be done
- Port allocation checks run with the `status` command
- Port allocation checks run as part of `up`, and collisions will prevent `pygmy` from starting any containers and will generate a report as to why no action was taken.
- `status` will report information now, where as logic prevented this before
- Travis now has a failure which is as yet unmitigated, but the failure means the program is working as designed.