### PR TITLE
#26: Add a weighting system

### DIFF
--- a/service/dnsmasq/dnsmasq.go
+++ b/service/dnsmasq/dnsmasq.go
@@ -10,6 +10,7 @@ import (
 func New() model.Service {
 	return model.Service{
 		Name: "amazeeio-dnsmasq",
+		Weight: 13,
 		Config:        container.Config{
 			Image: "andyshinn/dnsmasq:2.78",
 			Cmd: []string{

--- a/service/haproxy/haproxy.go
+++ b/service/haproxy/haproxy.go
@@ -10,6 +10,7 @@ import (
 func New() model.Service {
 	return model.Service{
 		Name: "amazeeio-haproxy",
+		Weight: 14,
 		Config: container.Config{
 			Image: "amazeeio/haproxy",
 			Labels: map[string]string{

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -29,6 +29,7 @@ type Service struct {
 	Disabled      bool
 	Discrete      bool
 	Output        bool
+	Weight 		  int
 	Config        container.Config
 	HostConfig    container.HostConfig
 	NetworkConfig network.NetworkingConfig

--- a/service/mailhog/mailhog.go
+++ b/service/mailhog/mailhog.go
@@ -10,6 +10,7 @@ import (
 func New() model.Service {
 	return model.Service{
 		Name: "mailhog.docker.amazee.io",
+		Weight: 15,
 		Config:        container.Config{
 			User:       "0",
 			ExposedPorts: nat.PortSet{

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -12,6 +12,7 @@ import (
 func New() model.Service {
 	return model.Service{
 		Name: "amazeeio-ssh-agent",
+		Weight: 30,
 		Config:        container.Config{
 			Image:    "amazeeio/ssh-agent",
 			Labels:		map[string]string{

--- a/service/ssh/key/ssh_addkey.go
+++ b/service/ssh/key/ssh_addkey.go
@@ -11,16 +11,17 @@ import (
 
 func NewAdder(key string) model.Service {
 	return model.Service{
-		Name: "amazeeio-ssh-agent-add-key",
+		Name:     "amazeeio-ssh-agent-add-key",
+		Weight:   31,
 		Discrete: true,
-		Output: true,
+		Output:   true,
 		Config: container.Config{
 			Image: "amazeeio/ssh-agent",
 			Cmd: []string{
 				"ssh-add",
 				key,
 			},
-			Labels:		map[string]string{
+			Labels: map[string]string{
 				"pygmy": "pygmy",
 			},
 		},
@@ -36,16 +37,17 @@ func NewAdder(key string) model.Service {
 
 func NewShower() model.Service {
 	return model.Service{
-		Name: "amazeeio-ssh-agent-show-keys",
+		Name:     "amazeeio-ssh-agent-show-keys",
+		Weight:   32,
 		Discrete: true,
-		Output: true,
+		Output:   true,
 		Config: container.Config{
 			Image: "amazeeio/ssh-agent",
 			Cmd: []string{
 				"ssh-add",
 				"-l",
 			},
-			Labels:		map[string]string{
+			Labels: map[string]string{
 				"pygmy": "pygmy",
 			},
 		},

--- a/service/ssh/key/ssh_addkey_win.go
+++ b/service/ssh/key/ssh_addkey_win.go
@@ -13,6 +13,7 @@ import (
 func NewAdder(key string) model.Service {
 	return model.Service{
 		Name:     "amazeeio-ssh-agent-add-key",
+		Weight:   31,
 		Discrete: true,
 		Output:   true,
 		Config: container.Config{
@@ -37,16 +38,17 @@ func NewAdder(key string) model.Service {
 
 func NewShower() model.Service {
 	return model.Service{
-		Name: "amazeeio-ssh-agent-show-keys",
+		Name:     "amazeeio-ssh-agent-show-keys",
+		Weight:   32,
 		Discrete: true,
-		Output: true,
+		Output:   true,
 		Config: container.Config{
 			Image: "amazeeio/ssh-agent",
 			Cmd: []string{
 				"ssh-add",
 				"-l",
 			},
-			Labels:		map[string]string{
+			Labels: map[string]string{
 				"pygmy": "pygmy",
 			},
 		},


### PR DESCRIPTION
The design of this program means all containers are treated equally - and that poses problems when the starting order matters. `docker-compose` normally handles this, but this doesn't use `docker-compose`.... It's pretty similar though.

So in the example of `ssh-agent`, key adding and listing.... we need finite control over the order.
This opens up that level of flexibility, and this was a planned feature.