### PR TITLE
Removes v1 references for now

### DIFF
--- a/cmd/addkey.go
+++ b/cmd/addkey.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/fubarhouse/pygmy/v1/service/library"
+	"github.com/fubarhouse/pygmy/service/library"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fubarhouse/pygmy/v1
+module github.com/fubarhouse/pygmy
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@
 
 package main
 
-import "github.com/fubarhouse/pygmy/v1/cmd"
+import "github.com/fubarhouse/pygmy/cmd"
 
 func main() {
 	cmd.Execute()

--- a/service/amazee/amazee.go
+++ b/service/amazee/amazee.go
@@ -3,7 +3,7 @@ package amazee
 import (
 	"fmt"
 	"github.com/docker/docker/api/types"
-	"github.com/fubarhouse/pygmy/v1/service/interface"
+	"github.com/fubarhouse/pygmy/service/interface"
 	"strings"
 )
 

--- a/service/dnsmasq/dnsmasq.go
+++ b/service/dnsmasq/dnsmasq.go
@@ -4,7 +4,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
+	model "github.com/fubarhouse/pygmy/service/interface"
 )
 
 func New() model.Service {

--- a/service/haproxy/haproxy.go
+++ b/service/haproxy/haproxy.go
@@ -3,8 +3,7 @@ package haproxy
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/go-connections/nat"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
+	model "github.com/fubarhouse/pygmy/service/interface"
 )
 
 func New() model.Service {
@@ -24,14 +23,6 @@ func New() model.Service {
 				Name              string
 				MaximumRetryCount int
 			}{Name: "always", MaximumRetryCount: 0},
-			PortBindings: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
-					{
-						HostIP:   "",
-						HostPort: "80",
-					},
-				},
-			},
 		},
 		NetworkConfig: network.NetworkingConfig{},
 	}

--- a/service/haproxy_connector/haproxy_connector.go
+++ b/service/haproxy_connector/haproxy_connector.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/client"
-	"github.com/fubarhouse/pygmy/v1/service/interface"
+	"github.com/fubarhouse/pygmy/service/interface"
 )
 
 func Connect(containerName string, network string) error {

--- a/service/library/clean.go
+++ b/service/library/clean.go
@@ -3,8 +3,8 @@ package library
 import (
 	"fmt"
 
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/resolv"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/resolv"
 )
 
 func Clean(c Config) {

--- a/service/library/down.go
+++ b/service/library/down.go
@@ -1,6 +1,6 @@
 package library
 
-import "github.com/fubarhouse/pygmy/v1/service/resolv"
+import "github.com/fubarhouse/pygmy/service/resolv"
 
 func Down(c Config) {
 

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -3,8 +3,8 @@ package library
 
 import (
 	"fmt"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/resolv"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/resolv"
 	"github.com/imdario/mergo"
 )
 

--- a/service/library/setup.go
+++ b/service/library/setup.go
@@ -2,18 +2,17 @@ package library
 
 import (
 	"fmt"
+	"github.com/fubarhouse/pygmy/service/dnsmasq"
+	"github.com/fubarhouse/pygmy/service/haproxy"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/mailhog"
+	"github.com/fubarhouse/pygmy/service/resolv"
+	"github.com/fubarhouse/pygmy/service/ssh/agent"
+	"github.com/fubarhouse/pygmy/service/ssh/key"
+	"github.com/spf13/viper"
 	"runtime"
 	"sort"
 	"strings"
-
-	"github.com/fubarhouse/pygmy/v1/service/dnsmasq"
-	"github.com/fubarhouse/pygmy/v1/service/haproxy"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/mailhog"
-	"github.com/fubarhouse/pygmy/v1/service/resolv"
-	"github.com/fubarhouse/pygmy/v1/service/ssh/agent"
-	"github.com/fubarhouse/pygmy/v1/service/ssh/key"
-	"github.com/spf13/viper"
 )
 
 func Setup(c *Config) {

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/fubarhouse/pygmy/v1/service/ssh/agent"
+	"github.com/fubarhouse/pygmy/service/ssh/agent"
 )
 
 func SshKeyAdd(c Config, key string) {

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fubarhouse/pygmy/v1/service/haproxy_connector"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/network"
-	"github.com/fubarhouse/pygmy/v1/service/resolv"
+	"github.com/fubarhouse/pygmy/service/haproxy_connector"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/network"
+	"github.com/fubarhouse/pygmy/service/resolv"
 )
 
 func Status(c Config) {

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -4,10 +4,10 @@ import (
 	"os"
 
 	"fmt"
-	"github.com/fubarhouse/pygmy/v1/service/haproxy_connector"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/network"
-	"github.com/fubarhouse/pygmy/v1/service/resolv"
+	"github.com/fubarhouse/pygmy/service/haproxy_connector"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/network"
+	"github.com/fubarhouse/pygmy/service/resolv"
 )
 
 func Up(c Config) {

--- a/service/library/update.go
+++ b/service/library/update.go
@@ -1,6 +1,6 @@
 package library
 
-import "github.com/fubarhouse/pygmy/v1/service/amazee"
+import "github.com/fubarhouse/pygmy/service/amazee"
 
 func Update(c Config) {
 	amazee.AmazeeImagePull()

--- a/service/mailhog/mailhog.go
+++ b/service/mailhog/mailhog.go
@@ -4,7 +4,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
+	model "github.com/fubarhouse/pygmy/service/interface"
 )
 
 func New() model.Service {

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/fubarhouse/pygmy/v1/service/interface"
+	"github.com/fubarhouse/pygmy/service/interface"
 )
 
 func Create(network string) error {

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
-	"github.com/fubarhouse/pygmy/v1/service/ssh/key"
+	model "github.com/fubarhouse/pygmy/service/interface"
+	"github.com/fubarhouse/pygmy/service/ssh/key"
 )
 
 func New() model.Service {

--- a/service/ssh/key/ssh_addkey.go
+++ b/service/ssh/key/ssh_addkey.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
+	model "github.com/fubarhouse/pygmy/service/interface"
 )
 
 func NewAdder(key string) model.Service {

--- a/service/ssh/key/ssh_addkey_win.go
+++ b/service/ssh/key/ssh_addkey_win.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	model "github.com/fubarhouse/pygmy/v1/service/interface"
+	model "github.com/fubarhouse/pygmy/service/interface"
 )
 
 func NewAdder(key string) model.Service {


### PR DESCRIPTION
Exporting the library is causing come `modules` pain, so the cleanest solution for the interim is to remove the problem. So, for now, this will not prevent anybody from consuming it.