### PR TITLE
#21: haproxy port defaults

### DIFF
--- a/service/haproxy/haproxy.go
+++ b/service/haproxy/haproxy.go
@@ -3,12 +3,13 @@ package haproxy
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
 	model "github.com/fubarhouse/pygmy-go/service/interface"
 )
 
 func New() model.Service {
 	return model.Service{
-		Name: "amazeeio-haproxy",
+		Name:   "amazeeio-haproxy",
 		Weight: 14,
 		Config: container.Config{
 			Image: "amazeeio/haproxy",
@@ -17,13 +18,29 @@ func New() model.Service {
 			},
 		},
 		HostConfig: container.HostConfig{
-			Binds:      []string{"/var/run/docker.sock:/tmp/docker.sock"},
-			AutoRemove: false,
+			Binds:        []string{"/var/run/docker.sock:/tmp/docker.sock"},
+			AutoRemove:   false,
+			PortBindings: nil,
 			RestartPolicy: struct {
 				Name              string
 				MaximumRetryCount int
 			}{Name: "always", MaximumRetryCount: 0},
 		},
 		NetworkConfig: network.NetworkingConfig{},
+	}
+}
+
+func NewDefaultPorts() model.Service {
+	return model.Service{
+		HostConfig: container.HostConfig{
+			PortBindings: nat.PortMap{
+				"80/tcp": []nat.PortBinding{
+					{
+						HostIP:   "",
+						HostPort: "80",
+					},
+				},
+			},
+		},
 	}
 }

--- a/service/library/setup.go
+++ b/service/library/setup.go
@@ -70,6 +70,15 @@ func Setup(c *Config) {
 		c.Services["amazeeio-haproxy"] = getService(haproxy.New(), c.Services["amazeeio-haproxy"])
 		c.Services["mailhog.docker.amazee.io"] = getService(mailhog.New(), c.Services["mailhog.docker.amazee.io"])
 		c.Services["amazeeio-ssh-agent"] = getService(agent.New(), c.Services["amazeeio-ssh-agent"])
+
+		// We need Port 80 to be configured by default.
+		// If a port on amazeeio-haproxy isn't explicitly declared,
+		// then we should set this value. This is far more creative
+		// than needed, so feel free to revisit if you can compile it.
+		if c.Services["amazeeio-haproxy"].HostConfig.PortBindings == nil {
+			c.Services["amazeeio-haproxy"] = getService(haproxy.NewDefaultPorts(), c.Services["amazeeio-haproxy"])
+		}
+
 	}
 
 	// It is because of interdependent containers we introduce a weighting system.


### PR DESCRIPTION
Allows for port binding to occur on haproxy even when no configuration options are set.
It'll check for a nil value and merge in some default settings - not a bad setup and could translate to the mailhog service.

This fixes a deal-breaking issue though - it's a priority.