### PR TITLE
use golang:alpine as builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as builder
+FROM golang:alpine as builder
 COPY main.go /go/src/github.com/fubarhouse/pygmy-go/
 COPY go.sum /go/src/github.com/fubarhouse/pygmy-go/
 COPY go.mod /go/src/github.com/fubarhouse/pygmy-go/


### PR DESCRIPTION
the full golang image is a hefty 800MB+ download - I've tested building with the alpine version (under half the size) on a couple of platforms and it looks to work ok.

Just an option - no hard feelings if there's a good reason for :latest 😈