### PR TITLE
#109: SSH rework

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -38,10 +38,20 @@ var restartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		Key, _ := cmd.Flags().GetString("key")
+		FoundKey := false
+		for _, v := range c.Keys {
+			if v == Key {
+				FoundKey = true
+			}
+		}
+
+		if !FoundKey {
+			c.Keys = append(c.Keys, Key)
+		}
+
 		c.SkipKey, _ = cmd.Flags().GetBool("no-addkey")
 
 		library.Restart(c)
-		library.SshKeyAdd(c, Key)
 
 	},
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -49,12 +49,12 @@ It includes dnsmasq, haproxy, mailhog, resolv and ssh-agent.`,
 				keyExistsInConfig = true
 			}
 		}
+
 		if !keyExistsInConfig {
 			c.Keys = append(c.Keys, Key)
 		}
 
 		library.Up(c)
-		library.SshKeyAdd(c, Key)
 
 	},
 }

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -418,6 +418,14 @@ func DockerRun(Service *Service) ([]byte, error) {
 		Service.Config.Labels["pygmy"] = "pygmy"
 	}
 
+	// Sanity check to ensure we don't get name conflicts.
+	c, _ := DockerContainerList()
+	for _, cn := range c {
+		if strings.HasSuffix(cn.Names[0], Service.Config.Labels["pygmy.name"])  {
+			return []byte{}, nil
+		}
+	}
+
 	// We need the container name.
 	name, e := Service.GetFieldString("name")
 	if e != nil {

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -103,7 +103,7 @@ func (Service *Service) Start() ([]byte, error) {
 	}
 
 	if c, err := GetRunning(Service); c.ID != "" {
-		if !Service.HostConfig.AutoRemove || !discrete {
+		if !Service.HostConfig.AutoRemove && !discrete {
 			fmt.Printf("Successfully started %v\n", name)
 		} else if !Service.HostConfig.AutoRemove {
 			// We cannot guarantee this container is running at this point if it is to be removed.

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -421,7 +421,7 @@ func DockerRun(Service *Service) ([]byte, error) {
 	// Sanity check to ensure we don't get name conflicts.
 	c, _ := DockerContainerList()
 	for _, cn := range c {
-		if strings.HasSuffix(cn.Names[0], Service.Config.Labels["pygmy.name"])  {
+		if strings.HasSuffix(cn.Names[0], Service.Config.Labels["pygmy.name"]) {
 			return []byte{}, nil
 		}
 	}

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -14,6 +14,7 @@ func Status(c Config) {
 
 	Setup(&c)
 	checks := DryRun(&c)
+	agentPresent := false
 
 	if len(checks) > 0 {
 		for _, check := range checks {
@@ -30,7 +31,11 @@ func Status(c Config) {
 				name, _ := Service.GetFieldString("name")
 				disabled, _ := Service.GetFieldBool("disabled")
 				discrete, _ := Service.GetFieldBool("discrete")
+				purpose, _ := Service.GetFieldString("purpose")
 				if name != "" {
+					if purpose == "sshagent" {
+						agentPresent = true
+					}
 					if !disabled && !discrete && name != "" {
 						if s, _ := Service.Status(); s {
 							fmt.Printf("[*] %v: Running as container %v\n", name, name)
@@ -92,6 +97,21 @@ func Status(c Config) {
 			// TODO re-fix
 			//Container.Output = true
 			Container.Start()
+		}
+	}
+
+	// Show ssh-keys in the agent
+	if agentPresent {
+		for _, v := range c.Services {
+			purpose, _ := v.GetFieldString("purpose")
+			if purpose == "showkeys" {
+				//v.Start()
+				out, _ := v.Start()
+				if len(string(out)) > 0 {
+					output := strings.Trim(string(out), "\n")
+					fmt.Println(output)
+				}
+			}
 		}
 	}
 

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -95,7 +95,7 @@ func Up(c Config) {
 	// Add ssh-keys to the agent
 	if agentPresent {
 		for _, v := range c.Keys {
-            out, err := SshKeyAdd(c, v)
+			out, err := SshKeyAdd(c, v)
 			if err != nil {
 				fmt.Println(err)
 			} else {

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -20,6 +20,11 @@ func New() types.NetworkResource {
 				},
 			},
 		},
+		Containers: map[string]types.EndpointResource{
+			"amazeeio-haproxy": types.EndpointResource{
+				Name: "amazeeio-haproxy",
+			},
+		},
 		Labels: map[string]string{
 			"pygmy": "pygmy",
 		},

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -16,6 +16,7 @@ func New() model.Service {
 			Labels: map[string]string{
 				"pygmy":         "pygmy",
 				"pygmy.name":    "amazeeio-ssh-agent",
+				"pygmy.output":  "false",
 				"pygmy.purpose": "sshagent",
 				"pygmy.weight":  "30",
 			},

--- a/service/ssh/key/ssh_addkey.go
+++ b/service/ssh/key/ssh_addkey.go
@@ -16,7 +16,7 @@ func NewAdder() model.Service {
 				"pygmy":          "pygmy",
 				"pygmy.name":     "amazeeio-ssh-agent-add-key",
 				"pygmy.discrete": "true",
-				"pygmy.output":   "true",
+				"pygmy.output":   "false",
 				"pygmy.purpose":  "addkeys",
 				"pygmy.weight":   "31",
 			},

--- a/service/ssh/key/ssh_addkey_win.go
+++ b/service/ssh/key/ssh_addkey_win.go
@@ -16,7 +16,7 @@ func NewAdder() model.Service {
 				"pygmy":          "pygmy",
 				"pygmy.name":     "amazeeio-ssh-agent-add-key",
 				"pygmy.discrete": "true",
-				"pygmy.output":   "true",
+				"pygmy.output":   "false",
 				"pygmy.purpose":  "addkeys",
 				"pygmy.weight":   "31",
 			},


### PR DESCRIPTION
Given SSH agent mechanisms were broken by the implementation details when tagging was adopted properly. This reworks almost the entire mechanism of SSH agent components.

* removes much duplication
* works consistently
* reworks container output mechanisms
* adds missing network container config

A followup PR will be created to ensure multiple keys can be supported equally as reliably.