### PR TITLE
#125: Cleanup missed output for docker volume already created

### DIFF
--- a/service/library/up.go
+++ b/service/library/up.go
@@ -36,7 +36,7 @@ func Up(c Config) {
 				fmt.Println(err)
 			}
 		} else {
-			fmt.Printf("Already created volume %v\n", volume)
+			fmt.Printf("Already created volume %v\n", volume.Name)
 		}
 	}
 


### PR DESCRIPTION
Resolves #125 - TIdy up output when has regressed since adopting official Docker API for volumes

This was forgotten previously and poses nothing more than aesthetics, the functionality still works.