### PR TITLE
#143: Pygmy should scan for created containers, not just running containers.

### DIFF
--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -350,7 +350,9 @@ func DockerContainerList() ([]types.Container, error) {
 		fmt.Println(err)
 	}
 
-	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{})
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All: true,
+	})
 	if err != nil {
 		return []types.Container{}, err
 	}


### PR DESCRIPTION
Resolves #143 