### PR TITLE
#140: Refactor mailhog container and add a range of container tests

### DIFF
--- a/.travis.pygmy.yml
+++ b/.travis.pygmy.yml
@@ -16,6 +16,14 @@ services:
         - pygmy.abracadabra: true
         - pygmy.opensesame: correct
 
+  amazeeio-mailhog:
+    Config:
+      Labels:
+        - pygmy.disabled: false
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
+
   amazeeio-ssh-agent:
     Config:
       Labels:
@@ -60,14 +68,6 @@ services:
           - HostPort: 8200
         9000/tcp:
           - HostPort: 8100
-
-  mailhog.docker.amazee.io:
-    Config:
-      Labels:
-        - pygmy.disabled: false
-        - pygmy.hocuspocus: 42
-        - pygmy.abracadabra: true
-        - pygmy.opensesame: correct
 
 volumes:
   portainer_data:

--- a/.travis.pygmy.yml
+++ b/.travis.pygmy.yml
@@ -1,19 +1,38 @@
 services:
 
+  amazeeio-dnsmasq:
+    Config:
+      Labels:
+        - pygmy.disabled: false
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
+
+  amazeeio-haproxy:
+    Config:
+      Labels:
+        - pygmy.disabled: false
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
+
   amazeeio-ssh-agent:
     Config:
       Labels:
-        - "pygmy.disabled": "false"
-
-  amazeeio-ssh-agent-show-keys:
-    Config:
-      Labels:
-        - "pygmy.disabled": "true"
+        - pygmy.disabled: false
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
 
   amazeeio-ssh-agent-add-key:
     Config:
       Labels:
-        - "pygmy.disabled": "true"
+        - pygmy.disabled: true
+
+  amazeeio-ssh-agent-show-keys:
+    Config:
+      Labels:
+        - pygmy.disabled: true
 
   amazeeio-portainer:
     Config:
@@ -23,10 +42,13 @@ services:
         - "AMAZEEIO_URL=portainer.docker.amazee.io"
         - "AMAZEEIO_HTTP_PORT=9000"
       Labels:
-        - "pygmy": "pygmy"
-        - "pygmy.name": "amazeeio-portainer"
-        - "pygmy.weight": "23"
-        - "pygmy.url": "http://portainer.docker.amazee.io"
+        - pygmy: pygmy
+        - pygmy.name: amazeeio-portainer
+        - pygmy.weight: 23
+        - pygmy.url: http://portainer.docker.amazee.io
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
       ExposedPorts:
         9000/tcp: {}
     HostConfig:
@@ -35,11 +57,17 @@ services:
         - portainer_data:/data
       PortBindings:
         8000/tcp:
-          -
-            HostPort: 8200
+          - HostPort: 8200
         9000/tcp:
-          -
-            HostPort: 8100
+          - HostPort: 8100
+
+  mailhog.docker.amazee.io:
+    Config:
+      Labels:
+        - pygmy.disabled: false
+        - pygmy.hocuspocus: 42
+        - pygmy.abracadabra: true
+        - pygmy.opensesame: correct
 
 volumes:
   portainer_data:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,28 @@ matrix:
         # Run pygmy
         - ./pygmy-go-linux-x86 --config .travis.pygmy.yml up;
         - ./pygmy-go-linux-x86 --config .travis.pygmy.yml status;
-        # Test stats page
-        - curl --HEAD http://docker.amazee.io/stats
+        # Test for configured container tags.
+        - >
+          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
+          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
+          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+        - >
+          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
+          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
+          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+        - >
+          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
+          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
+          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+        - >
+          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
+          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
+          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+        - >
+          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
+          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
+          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+
         # Real-world Drupal test.
         - git clone https://github.com/amazeeio/drupal-example.git drupal8-lagoon && cd drupal8-lagoon
         - docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,23 +22,23 @@ matrix:
         # Test for configured container tags.
         - >
           docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
           docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
           docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
           docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
           docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
 
         # Real-world Drupal test.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,25 +21,25 @@ matrix:
         - ./pygmy-go-linux-x86 --config .travis.pygmy.yml status;
         # Test for configured container tags.
         - >
-          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
 
         # Real-world Drupal test.
         - git clone https://github.com/amazeeio/drupal-example.git drupal8-lagoon && cd drupal8-lagoon

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,25 +21,25 @@ matrix:
         - ./pygmy-go-linux-x86 --config .travis.pygmy.yml status;
         # Test for configured container tags.
         - >
-          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
-          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
-          docker inspect amazeeio-dnsmasq         | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-dnsmasq         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
-          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
-          docker inspect amazeeio-haproxy         | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-haproxy         | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
-          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
-          docker inspect amazeeio-portainer       | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-portainer       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
-          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
-          docker inspect amazeeio-ssh-agent       | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect amazeeio-ssh-agent       | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
         - >
-          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.hocuspocus  | grep "42";
-          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.abracadabra | grep "true";
-          docker inspect mailhog.docker.amazee.io | jq .[].Config.Labels.pygmy.opensesame  | grep "correct";
+          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "true";
+          docker inspect mailhog.docker.amazee.io | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
 
         # Real-world Drupal test.
         - git clone https://github.com/amazeeio/drupal-example.git drupal8-lagoon && cd drupal8-lagoon

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -230,19 +230,21 @@ func (Service *Service) GetFieldBool(field string) (bool, error) {
 	f := fmt.Sprintf("pygmy.%v", field)
 
 	if container, running := GetRunning(Service); running == nil {
-		if val, ok := container.Labels[f]; ok {
-			if val == "true" {
-				return true, nil
-			} else if val == "false" {
-				return false, nil
+		if Service.Config.Labels[f] == container.Labels[f] {
+			if val, ok := container.Labels[f]; ok {
+				if val == "true" {
+					return true, nil
+				} else if val == "false" {
+					return false, nil
+				}
 			}
 		}
 	}
 
 	if val, ok := Service.Config.Labels[f]; ok {
-		if val == "true" {
+		if val == "true" || val == "1" {
 			return true, nil
-		} else if val == "false" {
+		} else if val == "false" || val == "0" {
 			return false, nil
 		}
 	}

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -39,7 +39,7 @@ type Config struct {
 }
 
 func mergeService(destination model.Service, src *model.Service) (*model.Service, error) {
-	if err := mergo.Merge(&destination, src, mergo.WithOverride); err != nil {
+	if err := mergo.Merge(&destination, src, mergo.WithAppendSlice); err != nil {
 		fmt.Println(err)
 		return src, err
 	}
@@ -52,7 +52,7 @@ func getService(s model.Service, c model.Service) model.Service {
 }
 
 func mergeNetwork(destination types.NetworkResource, src *types.NetworkResource) (*types.NetworkResource, error) {
-	if err := mergo.Merge(&destination, src, mergo.WithOverride); err != nil {
+	if err := mergo.Merge(&destination, src, mergo.WithAppendSlice); err != nil {
 		fmt.Println(err)
 		return src, err
 	}
@@ -65,7 +65,7 @@ func getNetwork(s types.NetworkResource, c types.NetworkResource) types.NetworkR
 }
 
 func mergeVolume(destination types.Volume, src *types.Volume) (*types.Volume, error) {
-	if err := mergo.Merge(&destination, src, mergo.WithOverride); err != nil {
+	if err := mergo.Merge(&destination, src, mergo.WithAppendSlice); err != nil {
 		fmt.Println(err)
 		return src, err
 	}

--- a/service/library/setup.go
+++ b/service/library/setup.go
@@ -67,7 +67,7 @@ func Setup(c *Config) {
 		c.Services["amazeeio-ssh-agent-add-key"] = getService(key.NewAdder(), c.Services["amazeeio-ssh-agent-add-key"])
 		c.Services["amazeeio-dnsmasq"] = getService(dnsmasq.New(), c.Services["amazeeio-dnsmasq"])
 		c.Services["amazeeio-haproxy"] = getService(haproxy.New(), c.Services["amazeeio-haproxy"])
-		c.Services["mailhog.docker.amazee.io"] = getService(mailhog.New(), c.Services["mailhog.docker.amazee.io"])
+		c.Services["amazeeio-mailhog"] = getService(mailhog.New(), c.Services["amazeeio-mailhog"])
 		c.Services["amazeeio-ssh-agent"] = getService(agent.New(), c.Services["amazeeio-ssh-agent"])
 
 		// We need Port 80 to be configured by default.
@@ -80,8 +80,8 @@ func Setup(c *Config) {
 
 		// It's sensible to use the same logic for port 1025.
 		// If a user needs to configure it, the default value should not be set also.
-		if c.Services["mailhog.docker.amazee.io"].HostConfig.PortBindings == nil {
-			c.Services["mailhog.docker.amazee.io"] = getService(mailhog.NewDefaultPorts(), c.Services["mailhog.docker.amazee.io"])
+		if c.Services["amazeeio-mailhog"].HostConfig.PortBindings == nil {
+			c.Services["amazeeio-mailhog"] = getService(mailhog.NewDefaultPorts(), c.Services["amazeeio-mailhog"])
 		}
 
 		// Ensure Networks has a at least a zero value.

--- a/service/mailhog/mailhog.go
+++ b/service/mailhog/mailhog.go
@@ -25,7 +25,7 @@ func New() model.Service {
 			Image: "mailhog/mailhog",
 			Labels: map[string]string{
 				"pygmy":        "pygmy",
-				"pygmy.name":   "mailhog.docker.amazee.io",
+				"pygmy.name":   "amazeeio-mailhog",
 				"pygmy.url":    "http://mailhog.docker.amazee.io",
 				"pygmy.weight": "15",
 			},

--- a/service/mailhog/mailhog.go
+++ b/service/mailhog/mailhog.go
@@ -21,6 +21,7 @@ func New() model.Service {
 				"MH_UI_BIND_ADDR=0.0.0.0:80",
 				"MH_API_BIND_ADDR=0.0.0.0:80",
 				"AMAZEEIO=AMAZEEIO",
+				"AMAZEEIO_URL=mailhog.docker.amazee.io",
 			},
 			Image: "mailhog/mailhog",
 			Labels: map[string]string{


### PR DESCRIPTION
Resolves #140 
Resolves #144 

This is an interesting change which takes the `mailhog.docker.amazee.io` container and renames it to `amazeeio-mailhog` to match the convention of the other containers. It also adds some tests to Travis to verify expected values found in the labels were transferred successfully from config to container and switches Mergo to use WithAppendSlice mode.

The main crux causing issues was that when a boolean was being passed as a value to a container label, it responds by assigning an integer equivalent to that boolean which means we needed to also handle the `0` and `1` case inside `GetFieldBool` which will also fix up missing issues elsewhere which depend on `if x` instead of just the default value `!x`.