### PR TITLE
Applied fix for Issue #196

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine as builder
+LABEL stage=builder
 COPY main.go /go/src/github.com/fubarhouse/pygmy-go/
 COPY go.sum /go/src/github.com/fubarhouse/pygmy-go/
 COPY go.mod /go/src/github.com/fubarhouse/pygmy-go/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
-DIR := $(PWD)
+SHELL := /bin/bash
+
+DIR := ${CURDIR}
 
 build:
 	docker build -t pygmy-go .
+	@echo "Removing binaries from previous build"
+	docker run -v $(DIR):/data pygmy-go rm -f /data/builds/pygmy-go*
+	@echo "Done"
+	@echo "Copying binaries to build directory"
 	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-x86 /data/builds/.
 	docker run -v $(DIR):/data pygmy-go cp pygmy-go-darwin /data/builds/.
 	docker run -v $(DIR):/data pygmy-go cp pygmy-go.exe /data/builds/.
+	@echo "Done"
+	@echo "Enjoy using pygmy-go binaries in $(DIR)/data/build directory."
 
 clean:
-	docker image rm pygmy-go
-
+	docker image rm -f pygmy-go
+	docker image prune -f --filter label=stage=builder
 


### PR DESCRIPTION
Fix for issue #196 
Root causes:
1- $(PWD) env variable only works in unix like systems. For supporting Powershell $(CURDIR) must be used
2- For "make clean" to remove intermediary images, images need to be labelled and --force must be used with --filter <label> when removing images

Tested both with Windows10/PS and MacOS. please see screenshots.

MacOS:
<img width="1509" alt="Screen Shot 2020-05-01 at 1 31 44 am" src="https://user-images.githubusercontent.com/2167226/80730991-a5e1c200-8b4d-11ea-9b2f-f1ac695f2d66.png">
<img width="929" alt="Screen Shot 2020-05-01 at 1 32 56 am" src="https://user-images.githubusercontent.com/2167226/80731007-aa0ddf80-8b4d-11ea-9dd2-69460596964c.png">

Windows10/PS:
![Capture20200501-001](https://user-images.githubusercontent.com/2167226/80731047-b98d2880-8b4d-11ea-8d05-32606293a31a.JPG)
![Capture20200501-002](https://user-images.githubusercontent.com/2167226/80731056-bdb94600-8b4d-11ea-8005-77f2f3aa708c.JPG)
