### PR TITLE
#198: golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
         - go get github.com/golangci/golangci-lint
+        - find / | grep golangci-lint
         - golangci-lint run
       script:
         # Build
@@ -29,6 +30,7 @@ matrix:
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
         - go get github.com/golangci/golangci-lint
+        - find / | grep golangci-lint
         - golangci-lint run
       script:
         # Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
+        - golangci-lint run
       script:
         # Build
         - make build
@@ -26,6 +27,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
+        - go get github.com/golangci/golangci-lint
       script:
         # Build
         - go build -o pygmy-go-linux-x86

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
         - go get github.com/golangci/golangci-lint
+        - go install github.com/golangci/golangci-lint
         - find / | grep golangci-lint
         - golangci-lint run
       script:
@@ -30,6 +31,7 @@ matrix:
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
         - go get github.com/golangci/golangci-lint
+        - go install github.com/golangci/golangci-lint
         - find / | grep golangci-lint
         - golangci-lint run
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
-        - go get github.com/golangci/golangci-lint
-        - go install github.com/golangci/golangci-lint
-        - find / | grep golangci-lint
-        - golangci-lint run
+        - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
         # Build
         - make build
@@ -30,10 +27,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
-        - go get github.com/golangci/golangci-lint
-        - go install github.com/golangci/golangci-lint
-        - find / | grep golangci-lint
-        - golangci-lint run
+        - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
         # Build
         - go build -o pygmy-go-linux-x86

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
+        - go get github.com/golangci/golangci-lint
         - golangci-lint run
       script:
         # Build
@@ -28,6 +29,7 @@ matrix:
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - GO111MODULE=on go vet $(go list ./...);
         - go get github.com/golangci/golangci-lint
+        - golangci-lint run
       script:
         # Build
         - go build -o pygmy-go-linux-x86

--- a/cmd/addkey.go
+++ b/cmd/addkey.go
@@ -39,7 +39,10 @@ var addkeyCmd = &cobra.Command{
 
 		Key, _ := cmd.Flags().GetString("key")
 
-		library.SshKeyAdd(c, Key, 0)
+		_, e := library.SshKeyAdd(c, Key, 0)
+		if e != nil {
+			fmt.Println(e)
+		}
 
 	},
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,6 @@ const (
 
 var (
 	dindID  string
-	dindErr string
 )
 
 type config struct {
@@ -97,7 +96,10 @@ func setup(t *testing.T, config *config) {
 				time.Sleep(time.Second * 2)
 			})
 
-			cli.ContainerStart(ctx, dindContainerName, types.ContainerStartOptions{})
+			e := cli.ContainerStart(ctx, dindContainerName, types.ContainerStartOptions{})
+			if e != nil {
+				fmt.Println(e)
+			}
 
 			for _, image := range config.images {
 				Convey("Pulling "+image, func() {
@@ -130,7 +132,10 @@ func setup(t *testing.T, config *config) {
 			})
 
 			// While it's safe, we should clean the environment.
-			model.DockerExec(dindContainerName, cleanCmd)
+			_, e := model.DockerExec(dindContainerName, cleanCmd)
+			if e != nil {
+				fmt.Println(e)
+			}
 
 			Convey("Default ports are not allocated", func() {
 				g, _ := model.DockerExec(dindContainerName, statusCmd)

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	dindID  string
+	dindID string
 )
 
 type config struct {

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -113,10 +113,10 @@ func (Service *Service) Start() ([]byte, error) {
 
 	if purpose == "addkeys" || purpose == "showkeys" {
 		if e := DockerKill(name); e != nil {
-			fmt.Println(e)
+			fmt.Sprintln(e)
 		}
 		if e := DockerRemove(name); e != nil {
-			fmt.Println(e)
+			fmt.Sprintln(e)
 		}
 
 	}

--- a/service/library/clean.go
+++ b/service/library/clean.go
@@ -35,7 +35,10 @@ func Clean(c Config) {
 	}
 
 	for _, network := range c.Networks {
-		model.DockerNetworkRemove(&network)
+		e := model.DockerNetworkRemove(&network)
+		if e != nil {
+			fmt.Println(e)
+		}
 		if s, _ := model.DockerNetworkStatus(&network); s {
 			fmt.Printf("Successfully removed network %v\n", network.Name)
 		} else {

--- a/service/library/down.go
+++ b/service/library/down.go
@@ -14,12 +14,18 @@ func Down(c Config) {
 	for _, Service := range c.Services {
 		enabled, _ := Service.GetFieldBool("enable")
 		if enabled {
-			Service.Stop()
+			e := Service.Stop()
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
 	}
 
 	for _, network := range c.Networks {
-		model.DockerNetworkRemove(&network)
+		e := model.DockerNetworkRemove(&network)
+		if e != nil {
+			fmt.Println(e)
+		}
 		if s, _ := model.DockerNetworkStatus(&network); s {
 			fmt.Printf("Successfully removed network %v\n", network.Name)
 		} else {

--- a/service/library/pull.go
+++ b/service/library/pull.go
@@ -1,6 +1,7 @@
 package library
 
 import (
+	"fmt"
 	"github.com/fubarhouse/pygmy-go/service/interface"
 )
 
@@ -10,7 +11,10 @@ func Pull(c Config) {
 
 	for _, Service := range c.Services {
 
-		model.DockerPull(Service.Config.Image)
+		_, e := model.DockerPull(Service.Config.Image)
+		if e != nil {
+			fmt.Print(e)
+		}
 
 	}
 }

--- a/service/library/setup.go
+++ b/service/library/setup.go
@@ -76,7 +76,7 @@ func Setup(c *Config) {
 	// If Services have been provided in complete or partially,
 	// this will override the defaults allowing any value to
 	// be changed by the user in the configuration file ~/.pygmy.yml
-	if c.Services == nil && c.Defaults == true {
+	if c.Services == nil && c.Defaults {
 		c.Services = make(map[string]model.Service, 6)
 	}
 
@@ -139,13 +139,13 @@ func Setup(c *Config) {
 		// Ensure Networks has a at least a zero value.
 		// We should provide defaults for amazeeio-network when no value is provided.
 		if c.Networks == nil {
-			c.Networks = make(map[string]types.NetworkResource, 0)
+			c.Networks = make(map[string]types.NetworkResource)
 			c.Networks["amazeeio-network"] = getNetwork(network.New(), c.Networks["amazeeio-network"])
 		}
 
 		// Ensure Volumes has a at least a zero value.
 		if c.Volumes == nil {
-			c.Volumes = make(map[string]types.Volume, 0)
+			c.Volumes = make(map[string]types.Volume)
 		}
 
 		for _, v := range c.Volumes {

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -43,13 +43,16 @@ func SshKeyAdd(c Config, key string, index int) ([]byte, error) {
 					// We need a brand new copy of the existing container config.
 					var newService model.Service
 					b, _ := json.Marshal(Container)
-					json.Unmarshal(b, &newService)
+					e := json.Unmarshal(b, &newService)
+					if e != nil {
+						fmt.Println(e)
+					}
 
 					name, _ := newService.GetFieldString("name")
 					name = strings.SplitAfter(name, "_")[0]
 
 					// For some reason Container works well here but it should be newService - needs investigation.
-					e := Container.SetField("name", fmt.Sprintf("%v_%v", name, index))
+					e = Container.SetField("name", fmt.Sprintf("%v_%v", name, index))
 
 					if e != nil {
 						fmt.Println(e)

--- a/service/resolv/interface.go
+++ b/service/resolv/interface.go
@@ -1,7 +1,0 @@
-package resolv
-
-type resolv interface {
-	Clean()
-	Configure()
-	Status() bool
-}


### PR DESCRIPTION
PR fixes issues identified by `golangci-lint` and also enforces tests done by `golangci-lint` to pass. The tests are more aggressive than `vet` or `test` - but they're in best practice and the work isn't difficult once initially supported.

* Resolves #198
* Resolves #53