### PR TITLE
Automate the version command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
+        - cat service/library/version.go | grep RELEASETAG
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -28,6 +29,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
+        - cat service/library/version.go | grep RELEASETAG
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -90,6 +92,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
+        - cat service/library/version.go | grep RELEASETAG
         - GO111MODULE=on go vet $(go list ./...);
 
       script:
@@ -103,6 +106,7 @@ matrix:
         - go mod download
         - GO111MODULE=on go vet $(go list ./...);
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
+        - cat service/library/version.go | grep RELEASETAG
 
       script:
         - export PYGMY_PATH=pygmy-go.exe;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
+        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -26,6 +27,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
+        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -35,6 +37,7 @@ matrix:
         - ./pygmy-go-linux-x86 status;
         - ./pygmy-go-linux-x86 --config examples/pygmy.travis.yml up;
         - ./pygmy-go-linux-x86 --config examples/pygmy.travis.yml status;
+        - ./pygmy-go-linux-x86 --config examples/pygmy.travis.yml version;
         # Test the amazeeio-network for expected results
         - >
           docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";
@@ -86,6 +89,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
+        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
 
       script:
@@ -98,6 +102,7 @@ matrix:
       before_install:
         - go mod download
         - GO111MODULE=on go vet $(go list ./...);
+        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
 
       script:
         - export PYGMY_PATH=pygmy-go.exe;
@@ -109,6 +114,7 @@ matrix:
         - cp pygmy-go.exe builds/pygmy-go.exe
 
         - builds/${PYGMY_PATH} --config examples/pygmy.travis.yml status;
+        - builds/${PYGMY_PATH} --config examples/pygmy.travis.yml version;
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
-        - cat service/library/version.go | grep RELEASETAG
+        - cat service/library/version.go | grep 'RELEASETAG = "'
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -29,7 +29,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
-        - cat service/library/version.go | grep RELEASETAG
+        - cat service/library/version.go | grep 'RELEASETAG = "'
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -92,7 +92,7 @@ matrix:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
-        - cat service/library/version.go | grep RELEASETAG
+        - cat service/library/version.go | grep 'RELEASETAG = "'
         - GO111MODULE=on go vet $(go list ./...);
 
       script:
@@ -106,7 +106,7 @@ matrix:
         - go mod download
         - GO111MODULE=on go vet $(go list ./...);
         - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
-        - cat service/library/version.go | grep RELEASETAG
+        - cat service/library/version.go | grep 'RELEASETAG = "'
 
       script:
         - export PYGMY_PATH=pygmy-go.exe;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
-        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
+        - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -27,7 +27,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
-        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
+        - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
         - docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.25.1 golangci-lint run -v
       script:
@@ -89,7 +89,7 @@ matrix:
       before_install:
         - go mod download
         - diff -u <(echo -n) <(gofmt -d $(find . -not -path "./vendor/*" -name "*.go"));
-        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
+        - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
         - GO111MODULE=on go vet $(go list ./...);
 
       script:
@@ -102,7 +102,7 @@ matrix:
       before_install:
         - go mod download
         - GO111MODULE=on go vet $(go list ./...);
-        - sed -i "s/RELEASETAG = \"\"/RELEASETAG = \"${TRAVIS_COMMIT}\"/g" service/library/version.go
+        - sed -i -e "s|RELEASETAG = \"\"|RELEASETAG = \"${TRAVIS_COMMIT}\"|g" service/library/version.go
 
       script:
         - export PYGMY_PATH=pygmy-go.exe;

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -11,12 +11,14 @@ import (
 var (
 	// Version tag used on local builds in Travis.
 	VERSIONTAG = os.Getenv("TRAVIS_COMMIT")
-)
 
-const (
 	// Fixed version which is modified via travis for the
 	// release builds. Should match version with v prepended.
 	RELEASETAG = ""
+
+	// Custom indicator will be added if changes are detected
+	// to pygmy, so it would read dev-xxxxxxx-custom
+	CUSTOMTAG = ""
 )
 
 // Version describes which version of Pygmy is running. This will be kept
@@ -26,7 +28,7 @@ const (
 func Version(c Config) {
 
 	// RELEASETAG will be provided via `sed` in the build pipeline.
-	if RELEASETAG != "" {
+	if RELEASETAG != "" && len(RELEASETAG) >= 7 {
 		if match, _ := regexp.Match("^v[0-9]+.[0-9]+.[0-9]+$", []byte(RELEASETAG)); match {
 			fmt.Printf("Pygmy %v\n", RELEASETAG)
 			return
@@ -39,22 +41,26 @@ func Version(c Config) {
 	// Get tags and reference information.
 	tags, _ := exec.Command("git", "show-ref", "--tags").Output()
 	ref, _ := exec.Command("git", "rev-parse", "HEAD").Output()
+	_, changes := exec.Command("git", "diff-index", "--quiet", "HEAD").Output()
+	if changes != nil {
+		CUSTOMTAG = "-custom"
+	}
 
 	// Scan the references from the tags to check if the current reference is
 	// associated to a tag. This is to show the tag version on a local build
 	// from source.
 	for _, tag := range strings.Split(string(tags), "\n") {
 		if strings.Contains(tag, string(ref)) {
-			fmt.Printf("Pygmy %v", strings.SplitAfter(tag, "/")[2])
+			fmt.Printf("Pygmy %v%v\n", strings.SplitAfter(tag, "/")[2], CUSTOMTAG)
 			return
 		}
 	}
 
 	if VERSIONTAG != "" {
 		// If the version tag isn't empty:
-		fmt.Printf("Pygmy %v", VERSIONTAG)
+		fmt.Printf("Pygmy %v%v", VERSIONTAG, CUSTOMTAG)
 	} else {
 		// If we don't have a version tag, use a reference.
-		fmt.Printf("Pygmy version dev-%v\n", string(ref[0:7]))
+		fmt.Printf("Pygmy version dev-%v%v\n", string(ref[0:7]), CUSTOMTAG)
 	}
 }

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -1,11 +1,57 @@
 package library
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var (
+	// Version tag used on local builds in Travis.
+	VERSIONTAG = os.Getenv("TRAVIS_COMMIT")
+)
+const (
+	// Fixed version which is modified via travis for the
+	// release builds. Should match version with v prepended.
+	RELEASETAG = ""
+)
 
 // Version describes which version of Pygmy is running. This will be kept
 // up to date as possible, and should be included in a release tag on the
 // master branch, and should be changed to something adequate immediately
 // after the release is published.
 func Version(c Config) {
-	fmt.Println("version called")
+
+	// RELEASETAG will be provided via `sed` in the build pipeline.
+	if RELEASETAG != "" {
+		if match, _ := regexp.MatchString(RELEASETAG, "^v[0-9]+.[0-9]+.[0-9]+$"); match {
+			fmt.Printf("Pygmy %v", RELEASETAG)
+		} else if match, _ := regexp.MatchString(RELEASETAG, "^[0-9a-zA-Z]+$"); match {
+			fmt.Printf("Pygmy version dev-%v", RELEASETAG)
+		}
+	}
+
+	// Get tags and reference information.
+	tags, _ := exec.Command("git", "show-ref", "--tags").Output()
+	ref, _ := exec.Command("git", "rev-parse", "HEAD").Output()
+
+	// Scan the references from the tags to check if the current reference is
+	// associated to a tag. This is to show the tag version on a local build
+	// from source.
+	for _, tag := range strings.Split(string(tags), "\n") {
+		if strings.Contains(tag, string(ref)) {
+			fmt.Printf("Pygmy %v", strings.SplitAfter(tag, "/")[2])
+			return
+		}
+	}
+
+	if VERSIONTAG != "" {
+		// If the version tag isn't empty:
+		fmt.Printf("Pygmy %v", VERSIONTAG)
+	} else {
+		// If we don't have a version tag, use a reference.
+		fmt.Printf("Pygmy version dev-%v\n", string(ref[0:7]))
+	}
 }

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -16,7 +16,7 @@ var (
 const (
 	// Fixed version which is modified via travis for the
 	// release builds. Should match version with v prepended.
-	RELEASETAG = ""
+	RELEASETAG = "625d30c517145f8e67da8354f66fe27c363ddea9"
 )
 
 // Version describes which version of Pygmy is running. This will be kept
@@ -27,10 +27,12 @@ func Version(c Config) {
 
 	// RELEASETAG will be provided via `sed` in the build pipeline.
 	if RELEASETAG != "" {
-		if match, _ := regexp.MatchString(RELEASETAG, "^v[0-9]+.[0-9]+.[0-9]+$"); match {
-			fmt.Printf("Pygmy %v", RELEASETAG)
-		} else if match, _ := regexp.MatchString(RELEASETAG, "^[0-9a-zA-Z]+$"); match {
-			fmt.Printf("Pygmy version dev-%v", RELEASETAG)
+		if match, _ := regexp.Match("^v[0-9]+.[0-9]+.[0-9]+$", []byte(RELEASETAG)); match {
+			fmt.Printf("Pygmy %v\n", RELEASETAG)
+			return
+		} else if match, _ := regexp.Match("^[0-9|a-z|A-Z]+$", []byte(RELEASETAG)); match {
+			fmt.Printf("Pygmy version dev-%v\n", RELEASETAG[0:7])
+			return
 		}
 	}
 

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -16,7 +16,7 @@ var (
 const (
 	// Fixed version which is modified via travis for the
 	// release builds. Should match version with v prepended.
-	RELEASETAG = "625d30c517145f8e67da8354f66fe27c363ddea9"
+	RELEASETAG = ""
 )
 
 // Version describes which version of Pygmy is running. This will be kept

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -12,6 +12,7 @@ var (
 	// Version tag used on local builds in Travis.
 	VERSIONTAG = os.Getenv("TRAVIS_COMMIT")
 )
+
 const (
 	// Fixed version which is modified via travis for the
 	// release builds. Should match version with v prepended.

--- a/service/library/version.go
+++ b/service/library/version.go
@@ -58,7 +58,7 @@ func Version(c Config) {
 
 	if VERSIONTAG != "" {
 		// If the version tag isn't empty:
-		fmt.Printf("Pygmy %v%v", VERSIONTAG, CUSTOMTAG)
+		fmt.Printf("Pygmy %v%v\n", VERSIONTAG, CUSTOMTAG)
 	} else {
 		// If we don't have a version tag, use a reference.
 		fmt.Printf("Pygmy version dev-%v%v\n", string(ref[0:7]), CUSTOMTAG)


### PR DESCRIPTION
For the longest time, the version subcommand has been forgotten... It was a manual task which was forgotten and automating it seems to be the best course of action.

This PR will automate the process and provide the version strings `vx.x.x`, `dev-xxxxxxx` or `dev-xxxxxxx-custom` for the following circumstances with or without additional configuration.

* a constant will be updated with the commit reference during CI
* running without compiling or using sed in CI will utilize `$TRAVIS_COMMIT`
* commit references will be cross-referenced with tags for local builds
* commit references will be used if there's no tag matching local builds
* if uncommitted changes to tracked files are detected, append `-custom` to output.