### PR TITLE
Revert "Bump github.com/imdario/mergo from 0.3.9 to 0.3.10"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/imdario/mergo v0.3.10
+	github.com/imdario/mergo v0.3.9
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.0 // indirect
 	github.com/moby/term v0.0.0-20200611042045-63b9a826fb74 // indirect
@@ -32,4 +32,5 @@ require (
 	golang.org/x/net v0.0.0-20200513185701-a91f0712d120 // indirect
 	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 	gopkg.in/ini.v1 v1.56.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
-github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=


### PR DESCRIPTION
Reverts fubarhouse/pygmy-go#240

Looks like `mergo` is having trouble upstream...

```
panic: reflect: reflect.flag.mustBeAssignable using unaddressable value

goroutine 1 [running]:
reflect.flag.mustBeAssignableSlow(0x99)
        /usr/lib/go/src/reflect/value.go:247 +0x138
reflect.flag.mustBeAssignable(...)
        /usr/lib/go/src/reflect/value.go:234
reflect.Value.Set(0x9e0280, 0xf9f198, 0x99, 0x9e0280, 0xf9f198, 0x99)
        /usr/lib/go/src/reflect/value.go:1533 +0x3b
github.com/imdario/mergo.deepMerge(0x9e0280, 0xf9f198, 0x99, 0x9e0280, 0xf9f198, 0x99, 0xc000927aa0, 0x3, 0xc00040a4c0, 0x0, ...)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:99 +0x32f7
github.com/imdario/mergo.deepMerge(0x9fbe60, 0xc0004f90b8, 0x195, 0x9fbe60, 0xc0004f8b38, 0x195, 0xc000927aa0, 0x2, 0xc00040a4c0, 0x0, ...)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:147 +0xa85
github.com/imdario/mergo.deepMerge(0xa7e540, 0xc0004f9080, 0x199, 0xa7e540, 0xc0004f8b00, 0x199, 0xc000927aa0, 0x1, 0xc00040a4c0, 0x0, ...)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:93 +0x31ed
github.com/imdario/mergo.deepMerge(0xa2f060, 0xc0004f9080, 0x199, 0xa2f060, 0xc0004f8b00, 0x199, 0xc000927aa0, 0x0, 0xc00040a4c0, 0x199, ...)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:93 +0x31ed
github.com/imdario/mergo.merge(0xa56060, 0xc0004f9080, 0xa56060, 0xc0004f8b00, 0xc000927bd0, 0x1, 0x1, 0x5, 0xc000425930)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:366 +0x32a
github.com/imdario/mergo.Merge(...)
        /home/karl/go/pkg/mod/github.com/imdario/mergo@v0.3.10/merge.go:296
github.com/fubarhouse/pygmy-go/service/library.mergeService(0x0, 0x0, 0x0, 0x0, 0xa8dc96, 0x1, 0x0, 0xc000390a20, 0x0, 0xc0000cf340, ...)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/library.go:39 +0xbf
github.com/fubarhouse/pygmy-go/service/library.getService(...)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/library.go:47
github.com/fubarhouse/pygmy-go/service/library.ImportDefaults(0xc00014e150, 0xa93313, 0x10, 0x0, 0x0, 0x0, 0x0, 0xa8dc96, 0x1, 0x0, ...)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/setup.go:36 +0x307
github.com/fubarhouse/pygmy-go/service/library.Setup(0xc00014e150)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/setup.go:129 +0x19f9
github.com/fubarhouse/pygmy-go/service/library.SshKeyAdd(0xc000291ee0, 0x1, 0x1, 0xc0002f8d50, 0xc0003a8ae0, 0x6, 0x6, 0xc00051a1b0, 0x1, 0xc0002e4730, ...)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/sshkeyadd.go:17 +0xa5
github.com/fubarhouse/pygmy-go/service/library.Up(0xc000291ee0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/service/library/up.go:133 +0xc7e
github.com/fubarhouse/pygmy-go/cmd.glob..func8(0xf6ab80, 0xf9f198, 0x0, 0x0)
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/cmd/up.go:62 +0x137
github.com/spf13/cobra.(*Command).execute(0xf6ab80, 0xf9f198, 0x0, 0x0, 0xf6ab80, 0xf9f198)
        /home/karl/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xf6a640, 0x443c6a, 0xf2ede0, 0xc000000180)
        /home/karl/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
        /home/karl/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/fubarhouse/pygmy-go/cmd.Execute()
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/cmd/root.go:55 +0x31
main.main()
        /home/karl/go/src/github.com/fubarhouse/pygmy-go/main.go:26 +0x20
```

Reverting the change fixes this problem while I tend to it later.