### PR TITLE
#276: Update logging mechanics

### DIFF
--- a/cmd/addkey.go
+++ b/cmd/addkey.go
@@ -39,7 +39,7 @@ var addkeyCmd = &cobra.Command{
 
 		Key, _ := cmd.Flags().GetString("key")
 
-		_, e := library.SshKeyAdd(c, Key, 0)
+		e := library.SshKeyAdd(c, Key, 0)
 		if e != nil {
 			fmt.Println(e)
 		}

--- a/service/interface/docker/docker.go
+++ b/service/interface/docker/docker.go
@@ -448,25 +448,26 @@ func DockerContainerStart(ID string, options types.ContainerStartOptions) error 
 	return err
 }
 
-func DockerContainerLogs(ID string, Follow bool) ([]byte, error) {
+func DockerContainerLogs(ID string) ([]byte, error) {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts()
 	cli.NegotiateAPIVersion(ctx)
 	if err != nil {
 		return []byte{}, err
 	}
-	b, _ := cli.ContainerLogs(ctx, ID, types.ContainerLogsOptions{
+	b, e := cli.ContainerLogs(ctx, ID, types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Follow:     Follow,
 	})
+
+	if e != nil {
+		return []byte{}, e
+	}
 
 	buf := new(bytes.Buffer)
 	if _, f := buf.ReadFrom(b); f != nil {
 		fmt.Println(f)
 	}
-
-	b.Close()
 
 	return buf.Bytes(), nil
 }

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -40,14 +40,15 @@ func (Service *Service) Setup() error {
 // Start will perform a series of checks to see if the container starting
 // is supposed be removed before-hand and will check to see if the
 // container is running before it is actually started.
-func (Service *Service) Start() ([]byte, error) {
+func (Service *Service) Start() error {
 
 	name, err := Service.GetFieldString("name")
 	discrete, _ := Service.GetFieldBool("discrete")
+	output, _ := Service.GetFieldBool("output")
 	purpose, _ := Service.GetFieldString("purpose")
 
 	if err != nil {
-		return []byte{}, nil
+		return nil
 	}
 
 	s := false
@@ -56,13 +57,13 @@ func (Service *Service) Start() ([]byte, error) {
 		var e error
 		s, e = Service.Status()
 		if e != nil {
-			return []byte{}, e
+			return e
 		}
 	}
 
 	if s && !Service.HostConfig.AutoRemove && !discrete {
 		fmt.Printf("Already running %v\n", name)
-		return []byte{}, nil
+		return nil
 	}
 
 	if purpose == "addkeys" || purpose == "showkeys" {
@@ -75,21 +76,28 @@ func (Service *Service) Start() ([]byte, error) {
 
 	}
 
-	output, err := Service.DockerRun()
+	err = Service.DockerRun()
 	if err != nil {
-		return []byte{}, err
+		return err
+	}
+
+	l, _ := Service.DockerLogs()
+	if output && string(l) != "" {
+		fmt.Println(string(l))
 	}
 
 	if c, err := Service.GetRunning(); c.ID != "" {
-		if !Service.HostConfig.AutoRemove && !discrete {
+		if !discrete {
 			fmt.Printf("Successfully started %v\n", name)
-		} else if Service.HostConfig.AutoRemove && err != nil {
+			return nil
+		}
+		if err != nil {
 			// We cannot guarantee this container is running at this point if it is to be removed.
-			return output, fmt.Errorf("Failed to run %v: %v\n", name, err)
+			return fmt.Errorf("Failed to run %v: %v\n", name, err)
 		}
 	}
 
-	return output, nil
+	return nil
 }
 
 // Status will check if the container is running.
@@ -200,14 +208,37 @@ func (Service *Service) Stop() error {
 // _ will ensure DockerService is implemented by Service.
 var _ DockerService = (*Service)(nil)
 
-// DockerRun will setup and run a given container.
-func (Service *Service) DockerRun() ([]byte, error) {
-
+// DockerLogs will return the logs from the container.
+func (Service *Service) DockerLogs() ([]byte, error) {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts()
 	cli.NegotiateAPIVersion(ctx)
 	if err != nil {
 		return []byte{}, err
+	}
+
+	name, e := Service.GetFieldString("name")
+	log, e := docker.DockerContainerLogs(name)
+
+	if e != nil {
+		return []byte{}, err
+	}
+
+	if string(log) != "" {
+		return log, nil
+	}
+
+	return []byte{}, nil
+}
+
+// DockerRun will setup and run a given container.
+func (Service *Service) DockerRun() error {
+
+	ctx := context.Background()
+	cli, err := client.NewClientWithOpts()
+	cli.NegotiateAPIVersion(ctx)
+	if err != nil {
+		return err
 	}
 
 	// Ensure we have the image available:
@@ -240,25 +271,25 @@ func (Service *Service) DockerRun() ([]byte, error) {
 	c, _ := docker.DockerContainerList()
 	for _, cn := range c {
 		if strings.HasSuffix(cn.Names[0], Service.Config.Labels["pygmy.name"]) {
-			return []byte{}, nil
+			return nil
 		}
 	}
 
 	// We need the container name.
 	name, e := Service.GetFieldString("name")
 	if e != nil {
-		return []byte{}, fmt.Errorf("container config is missing label for name")
+		return fmt.Errorf("container config is missing label for name")
 	}
 
-	resp, err := docker.DockerContainerCreate(name, Service.Config, Service.HostConfig, Service.NetworkConfig)
+	_, err = docker.DockerContainerCreate(name, Service.Config, Service.HostConfig, Service.NetworkConfig)
 	if err != nil {
-		return []byte{}, err
+		return err
 	}
 
 	if err := docker.DockerContainerStart(name, types.ContainerStartOptions{}); err != nil {
-		return []byte{}, err
+		return err
 	}
 
-	return docker.DockerContainerLogs(resp.ID, Service.HostConfig.AutoRemove)
+	return nil
 
 }

--- a/service/interface/interface.go
+++ b/service/interface/interface.go
@@ -217,7 +217,7 @@ func (Service *Service) DockerLogs() ([]byte, error) {
 		return []byte{}, err
 	}
 
-	name, e := Service.GetFieldString("name")
+	name, _ := Service.GetFieldString("name")
 	log, e := docker.DockerContainerLogs(name)
 
 	if e != nil {

--- a/service/interface/types.go
+++ b/service/interface/types.go
@@ -13,7 +13,7 @@ import (
 type DockerService interface {
 	Setup() error
 	Status() (bool, error)
-	Start() ([]byte, error)
+	Start() error
 	Stop() error
 }
 

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -28,7 +28,6 @@ func SshKeyAdd(c Config, key string, index int) error {
 	for _, Container := range c.Services {
 		purpose, _ := Container.GetFieldString("purpose")
 		if purpose == "addkeys" {
-			fmt.Println(agent.Search(Container, key))
 			if !agent.Search(Container, key) {
 				if runtime.GOOS == "windows" {
 					Container.Config.Cmd = []string{"ssh-add", "/key"}

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -65,8 +65,12 @@ func SshKeyAdd(c Config, key string, index int) error {
 					if e != nil {
 						return e
 					}
-					if string(l) != "" {
-						fmt.Println(string(l))
+
+					// We need tighter control on the output of this container...
+					for _, line := range strings.Split(string(l), "\n") {
+						if strings.Contains(line, "Identity added:") {
+							fmt.Println(line)
+						}
 					}
 
 				} else {
@@ -79,8 +83,12 @@ func SshKeyAdd(c Config, key string, index int) error {
 					if e != nil {
 						return e
 					}
-					if string(l) != "" {
-						fmt.Println(string(l))
+
+					// We need tighter control on the output of this container...
+					for _, line := range strings.Split(string(l), "\n") {
+						if strings.Contains(line, "Identity added:") {
+							fmt.Println(line)
+						}
 					}
 
 				}

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -28,6 +28,7 @@ func SshKeyAdd(c Config, key string, index int) error {
 	for _, Container := range c.Services {
 		purpose, _ := Container.GetFieldString("purpose")
 		if purpose == "addkeys" {
+			fmt.Println(agent.Search(Container, key))
 			if !agent.Search(Container, key) {
 				if runtime.GOOS == "windows" {
 					Container.Config.Cmd = []string{"ssh-add", "/key"}
@@ -57,7 +58,10 @@ func SshKeyAdd(c Config, key string, index int) error {
 						fmt.Println(e)
 					}
 
-					newService.Start()
+					e = newService.Start()
+					if e != nil {
+						return e
+					}
 					l, e := newService.DockerLogs()
 					if e != nil {
 						return e
@@ -68,7 +72,10 @@ func SshKeyAdd(c Config, key string, index int) error {
 
 				} else {
 
-					Container.Start()
+					e := Container.Start()
+					if e != nil {
+						return e
+					}
 					l, e := Container.DockerLogs()
 					if e != nil {
 						return e

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -12,18 +12,17 @@ import (
 )
 
 // SshKeyAdd will add a given key to the ssh agent.
-func SshKeyAdd(c Config, key string, index int) ([]byte, error) {
+func SshKeyAdd(c Config, key string, index int) error {
 
 	Setup(&c)
 
 	if key != "" {
 		if _, err := os.Stat(key); err != nil {
 			fmt.Printf("%v\n", err)
-			return []byte{}, err
+			return err
 		}
 	}
 
-	var b []byte
 	var e error
 
 	for _, Container := range c.Services {
@@ -58,11 +57,25 @@ func SshKeyAdd(c Config, key string, index int) ([]byte, error) {
 						fmt.Println(e)
 					}
 
-					return newService.Start()
+					newService.Start()
+					l, e := newService.DockerLogs()
+					if e != nil {
+						return e
+					}
+					if string(l) != "" {
+						fmt.Println(string(l))
+					}
 
 				} else {
 
-					return Container.Start()
+					Container.Start()
+					l, e := Container.DockerLogs()
+					if e != nil {
+						return e
+					}
+					if string(l) != "" {
+						fmt.Println(string(l))
+					}
 
 				}
 
@@ -70,5 +83,5 @@ func SshKeyAdd(c Config, key string, index int) ([]byte, error) {
 		}
 
 	}
-	return b, e
+	return e
 }

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -90,7 +90,10 @@ func Status(c Config) {
 		for _, v := range c.Services {
 			purpose, _ := v.GetFieldString("purpose")
 			if purpose == "showkeys" {
-				v.Start()
+				e := v.Start()
+				if e != nil {
+					fmt.Println(e)
+				}
 				l, _ := v.DockerLogs()
 				if len(string(l)) > 0 {
 					output := strings.Trim(string(l), "\n")

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -90,9 +90,10 @@ func Status(c Config) {
 		for _, v := range c.Services {
 			purpose, _ := v.GetFieldString("purpose")
 			if purpose == "showkeys" {
-				out, _ := v.Start()
-				if len(string(out)) > 0 {
-					output := strings.Trim(string(out), "\n")
+				v.Start()
+				l, _ := v.DockerLogs()
+				if len(string(l)) > 0 {
+					output := strings.Trim(string(l), "\n")
 					fmt.Println(output)
 				}
 			}

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -75,7 +75,10 @@ func Up(c Config) {
 				}
 			}
 
-			service.Start()
+			e := service.Start()
+			if e != nil {
+				fmt.Println(e)
+			}
 		}
 
 		// If one or more agent was found:

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -49,7 +49,6 @@ func Up(c Config) {
 		service := c.Services[s]
 		enabled, _ := service.GetFieldBool("enable")
 		purpose, _ := service.GetFieldString("purpose")
-		output, _ := service.GetFieldBool("output")
 
 		// Do not show or add keys:
 		if enabled && purpose != "addkeys" && purpose != "showkeys" {
@@ -76,10 +75,7 @@ func Up(c Config) {
 				}
 			}
 
-			o, _ := service.Start()
-			if output && string(o) != "" {
-				fmt.Println(string(o))
-			}
+			service.Start()
 		}
 
 		// If one or more agent was found:
@@ -133,11 +129,9 @@ func Up(c Config) {
 	if agentPresent {
 		i := 1
 		for _, v := range c.Keys {
-			out, err := SshKeyAdd(c, v, i)
+			err := SshKeyAdd(c, v, i)
 			if err != nil {
 				fmt.Println(err)
-			} else if string(out) != "" {
-				fmt.Println(strings.Trim(string(out), "\n"))
 			}
 			i++
 		}

--- a/service/library/update.go
+++ b/service/library/update.go
@@ -36,7 +36,7 @@ func Update(c Config) {
 				fmt.Println(e)
 			}
 			if s, _ := service.Status(); !s {
-				_, e = service.Start()
+				e = service.Start()
 				if e != nil {
 					fmt.Println(e)
 				}

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -57,7 +57,7 @@ func Search(service model.Service, key string) bool {
 	result := false
 	if _, err := os.Stat(key); !os.IsNotExist(err) {
 		stripped := strings.Trim(key, ".pub")
-		data, err := ioutil.ReadFile(stripped+".pub")
+		data, err := ioutil.ReadFile(stripped + ".pub")
 		if err != nil {
 			fmt.Println(err)
 			return false

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -39,26 +39,25 @@ func New() model.Service {
 // SshKeyLister will grab the output of all running containers with the proper
 // config after starting them, and return it.
 // which is indicated by the purpose tag.
-func List(service model.Service) []string {
-	var r []byte
+func List(service model.Service) ([]byte, error) {
 	purpose, _ := service.GetFieldString("purpose")
 	if purpose == "showkeys" {
-		r, _ = service.Start()
+		service.Start()
 	}
-	return strings.Split(string(r), "\n")
+	return service.DockerLogs()
 }
 
 // Search will determine if an SSH key has been added to the agent.
 func Search(service model.Service, key string) bool {
 	if _, err := os.Stat(key); !os.IsNotExist(err) {
 
-		items := List(service)
+		items, _ := List(service)
 
 		if len(items) == 0 {
 			return false
 		}
 
-		for _, item := range items {
+		for _, item := range strings.Split(string(items), "\n") {
 			if strings.Contains(item, "The agent has no identities") {
 				return false
 			}

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -65,12 +65,9 @@ func Search(service model.Service, key string) bool {
 
 		items, _ := List(service)
 
-		fmt.Println(items)
-
 		if len(items) == 0 {
 			return false
 		}
-
 
 		for _, item := range strings.Split(string(items), "\n") {
 			if strings.Contains(item, "The agent has no identities") {

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -42,29 +44,42 @@ func New() model.Service {
 func List(service model.Service) ([]byte, error) {
 	purpose, _ := service.GetFieldString("purpose")
 	if purpose == "showkeys" {
-		service.Start()
+		e := service.Start()
+		if e != nil {
+			return []byte{}, e
+		}
 	}
 	return service.DockerLogs()
 }
 
 // Search will determine if an SSH key has been added to the agent.
 func Search(service model.Service, key string) bool {
+	result := false
 	if _, err := os.Stat(key); !os.IsNotExist(err) {
+		stripped := strings.Trim(key, ".pub")
+		data, err := ioutil.ReadFile(stripped+".pub")
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
 
 		items, _ := List(service)
+
+		fmt.Println(items)
 
 		if len(items) == 0 {
 			return false
 		}
 
+
 		for _, item := range strings.Split(string(items), "\n") {
 			if strings.Contains(item, "The agent has no identities") {
 				return false
 			}
-			if strings.Contains(item, key) {
-				return true
+			if strings.Contains(item, string(data)) {
+				result = true
 			}
 		}
 	}
-	return false
+	return result
 }

--- a/service/ssh/agent/ssh_agent_test.go
+++ b/service/ssh/agent/ssh_agent_test.go
@@ -1,6 +1,7 @@
 package agent_test
 
 import (
+	"fmt"
 	"testing"
 
 	model "github.com/fubarhouse/pygmy-go/service/interface"
@@ -13,7 +14,10 @@ func Example() {
 }
 
 func ExampleList() {
-	agent.List(model.Service{})
+	_, e := agent.List(model.Service{})
+	if e != nil {
+		fmt.Println(e)
+	}
 }
 
 func ExampleSearch() {


### PR DESCRIPTION
Resolves #276 

This decouples the container log reporting mechanism to its own isolated functionality. So instead of being integrated with the container start API it'll call the logging mechanism independently to get the container logs regardless of the container state (running, terminated etc).

This solution is a lot more stable and predictable when regarding a broad range of use cases instead of the expected behavior. The `cowsay` example, for example, is a lot more predictable now instead of being hit and miss depending on the platform.