### PR TITLE
Goreleaser schema update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - arm64
 
 brews:
-  - github:
+  - tap:
       owner: fubarhouse
       name: homebrew-pygmy-go
     folder: Formula


### PR DESCRIPTION
Resolves #284.

Perhaps this will be the first part of a two-phase update to fix goreleaser.