### PR TITLE
#303: Add build targets for linux/386 & darwin/arm64

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -230,11 +230,3 @@ jobs:
 
       - name: Cleanup after tests.
         run: docker system prune --all --force
-
-  slack:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -72,16 +72,16 @@ jobs:
           sudo dpkg -i --ignore-depends=docker-ce lando-stable.deb;
 
       - name: Compile
-        run: go build -o pygmy-go-linux-x86
+        run: go build -o pygmy-go-linux-arm
 
       - name: Basic test
         run: |
-          ./pygmy-go-linux-x86 pull;
-          ./pygmy-go-linux-x86 pull;
-          ./pygmy-go-linux-x86 status;
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml up;
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml status;
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml version;
+          ./pygmy-go-linux-arm pull;
+          ./pygmy-go-linux-arm pull;
+          ./pygmy-go-linux-arm status;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml up;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml status;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml version;
 
       - name: Test the amazeeio-network for expected results
         run: |
@@ -123,7 +123,7 @@ jobs:
           sleep 5;
           curl --HEAD http://drupal8-example-simple.docker.amazee.io;
           curl --HEAD http://drupal8-example-simple.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-go-linux-x86 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal8-example-simple.docker.amazee.io';
+          ../../pygmy-go-linux-arm --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal8-example-simple.docker.amazee.io';
           docker-compose -p drupal8-example-simple down;
           docker-compose -p drupal8-example-simple rm;
           cd ../../;
@@ -136,7 +136,7 @@ jobs:
           sleep 5;
           curl --HEAD http://drupal9-example-advanced.docker.amazee.io;
           curl --HEAD http://drupal9-example-advanced.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-go-linux-x86 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.docker.amazee.io';
+          ../../pygmy-go-linux-arm --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.docker.amazee.io';
           docker-compose -p drupal9-advanced down;
           docker-compose -p drupal9-advanced rm;
           cd ../../;
@@ -149,7 +149,7 @@ jobs:
           sleep 5;
           curl --HEAD http://drupal9-example-simple.docker.amazee.io;
           curl --HEAD http://drupal9-example-simple.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-go-linux-x86 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-simple.docker.amazee.io';
+          ../../pygmy-go-linux-arm --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-simple.docker.amazee.io';
           docker-compose -p drupal-example-simple down;
           docker-compose -p drupal-example-simple rm;
           cd ../../;
@@ -161,7 +161,7 @@ jobs:
           docker-compose -p node up -d;
           curl --HEAD http://node.docker.amazee.io;
           curl --HEAD http://node.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-go-linux-x86 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.docker.amazee.io';
+          ../../pygmy-go-linux-arm --config ../../examples/pygmy.basic.yml status | grep '\- http://node.docker.amazee.io';
           docker-compose -p node down;
           docker-compose -p node rm;
           cd ../../;
@@ -199,7 +199,7 @@ jobs:
           sleep 5;
           curl --HEAD http://wordpress-nginx.docker.amazee.io;
           curl --HEAD http://wordpress-nginx.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-go-linux-x86 --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-nginx.docker.amazee.io';
+          ../../pygmy-go-linux-arm --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-nginx.docker.amazee.io';
           docker-compose -p wordpress-simple down;
           docker-compose -p wordpress-simple rm;
           cd ../../;
@@ -216,17 +216,17 @@ jobs:
 
       - name: Test the down command
         run: |
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml down | grep 'Successfully stopped amazeeio';
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml status | grep '\[ \] amazeeio-' | grep 'is not running';
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && false || true;
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml up;
-          ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && true || false;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml down | grep 'Successfully stopped amazeeio';
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml status | grep '\[ \] amazeeio-' | grep 'is not running';
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && false || true;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml up;
+          ./pygmy-go-linux-arm --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && true || false;
 
       - name: Cowsay test
-        run: ./pygmy-go-linux-x86 --config examples/pygmy.basic.yml up | grep 'holy ship' || true;
+        run: ./pygmy-go-linux-arm --config examples/pygmy.basic.yml up | grep 'holy ship' || true;
 
       - name: Cleanup pygmy
-        run: ./pygmy-go-linux-x86 clean;
+        run: ./pygmy-go-linux-arm clean;
 
       - name: Cleanup after tests.
         run: docker system prune --all --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,16 @@ COPY cmd/ /go/src/github.com/fubarhouse/pygmy-go/cmd/
 COPY service/ /go/src/github.com/fubarhouse/pygmy-go/service/
 
 WORKDIR /go/src/github.com/fubarhouse/pygmy-go/
-RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o pygmy-go-linux-x86 .
+RUN GO111MODULE=on GOOS=linux GOARCH=386 go build -o pygmy-go-linux .
+RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o pygmy-go-linux-arm .
 RUN GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -o pygmy-go-darwin .
+RUN GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -o pygmy-go-darwin-arm .
 RUN GO111MODULE=on GOOS=windows GOARCH=amd64 go build -o pygmy-go.exe .
 
 FROM alpine
 WORKDIR /app
+COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go-linux .
+COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go-linux-arm .
 COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go-darwin .
-COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go-linux-x86 .
+COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go-darwin-arm .
 COPY --from=builder /go/src/github.com/fubarhouse/pygmy-go/pygmy-go.exe .

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ build:
 	docker run -v $(DIR):/data pygmy-go rm -f /data/builds/pygmy-go*
 	@echo "Done"
 	@echo "Copying binaries to build directory"
-	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-x86 /data/builds/.
+	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux /data/builds/.
+	docker run -v $(DIR):/data pygmy-go cp pygmy-go-linux-arm /data/builds/.
 	docker run -v $(DIR):/data pygmy-go cp pygmy-go-darwin /data/builds/.
+	docker run -v $(DIR):/data pygmy-go cp pygmy-go-darwin-arm /data/builds/.
 	docker run -v $(DIR):/data pygmy-go cp pygmy-go.exe /data/builds/.
 	@echo "Done"
 	@echo "Enjoy using pygmy-go binaries in $(DIR)/build directory."

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dindContainerName = "exampleTestContainer"
-	binaryReference   = "pygmy-go-linux-x86"
+	binaryReference   = "pygmy-go-linux-arm64"
 )
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dindContainerName = "exampleTestContainer"
-	binaryReference   = "pygmy-go-linux-arm64"
+	binaryReference   = "pygmy-go-linux-arm"
 )
 
 var (


### PR DESCRIPTION
This PR resolves #303 

* Changes build target for linux/arm64
  `linux/arm64` builds and outputs to `pygmy-go-linux-x86`, this changes the output file to be accurate, another target has been added as a follow-up to this action.
* Adds build target for linux/386
* Adds build target for darwin/arm64