### PR TITLE
#323: Open haproxy to port 443 by default

### DIFF
--- a/service/haproxy/haproxy.go
+++ b/service/haproxy/haproxy.go
@@ -51,6 +51,12 @@ func NewDefaultPorts() model.Service {
 						HostPort: "80",
 					},
 				},
+				"443/tcp": []nat.PortBinding{
+					{
+						HostIP:   "",
+						HostPort: "443",
+					},
+				},
 			},
 		},
 	}

--- a/service/haproxy/haproxy_test.go
+++ b/service/haproxy/haproxy_test.go
@@ -31,6 +31,6 @@ func Test(t *testing.T) {
 		So(obj.HostConfig.PortBindings, ShouldEqual, nil)
 		So(obj.HostConfig.RestartPolicy.Name, ShouldEqual, "unless-stopped")
 		So(obj.HostConfig.RestartPolicy.MaximumRetryCount, ShouldEqual, 0)
-		So(fmt.Sprint(objPorts.HostConfig.PortBindings), ShouldEqual, fmt.Sprint(nat.PortMap{"80/tcp": []nat.PortBinding{{HostIP: "", HostPort: "80"}}}))
+		So(fmt.Sprint(objPorts.HostConfig.PortBindings), ShouldEqual, fmt.Sprint(nat.PortMap{"80/tcp": []nat.PortBinding{{HostIP: "", HostPort: "80"}}, "443/tcp": []nat.PortBinding{{HostIP: "", HostPort: "443"}}}))
 	})
 }


### PR DESCRIPTION
This PR resolves #323.

* Match up the port configuration with the Ruby version of Pygmy (https://github.com/amazeeio/pygmy/blob/master/lib/pygmy/haproxy.rb#L17)
* Update field tests to pass.

Looking to schedule a release after this one too for the convenience of users.