### PR TITLE
[WIP] Only run linux containers

### DIFF
--- a/service/interface/docker/docker.go
+++ b/service/interface/docker/docker.go
@@ -451,11 +451,8 @@ func DockerContainerCreate(ID string, config container.Config, hostconfig contai
 	}
 	platform := platforms.Normalize(v1.Platform{
 		Architecture: runtime.GOARCH,
-		OS:           runtime.GOOS,
+		OS:           "linux",
 	})
-	if runtime.GOOS == "darwin" {
-		platform.OS = "linux"
-	}
 	resp, err := cli.ContainerCreate(ctx, &config, &hostconfig, &networkconfig, &platform, ID)
 	if err != nil {
 		return container.ContainerCreateCreatedBody{}, err


### PR DESCRIPTION
In the event PowerShell tests on `main` will fail, this will address it.
This is both precautionary and preemptive - unless manual testing on PowerShell does not fail.