### PR TITLE
Dynamic service names & domain

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -56,6 +56,8 @@ jobs:
 
   full:
     runs-on: ubuntu-18.04
+    env:
+      PYGMY_DOMAIN: docker.amazee.io
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -108,40 +108,40 @@ jobs:
           ./pygmy-linux-amd64 addkey /home/runner/.ssh/id_rsa.pub;
           ./pygmy-linux-amd64 status;
           ./pygmy-linux-amd64 status | grep 'id_rsa';
-          docker run --rm -i --volumes-from amazeeio-ssh-agent uselagoon/php-7.4-cli /usr/bin/ssh-add -l | grep 'id_rsa';
+          docker run --rm -i --volumes-from pygmy-ssh-agent uselagoon/php-7.4-cli /usr/bin/ssh-add -l | grep 'id_rsa';
 
       - name: Resolv file test
         run: |
-          stat /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
-          grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
-          grep "docker.amazee.io" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
+          stat /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
+          grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
+          grep "pygmy.site" /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
 
-      - name: Test the amazeeio-network for expected results
+      - name: Test the pygmy-network for expected results
         run: |
-          docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-haproxy";
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-mailhog";
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-portainer";
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address';
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address' | grep "10.99.99.";
+          docker network inspect pygmy-network | jq '.[].Name' | grep "pygmy-network";
+          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-haproxy";
+          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-mailhog";
+          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-portainer";
+          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].IPv4Address';
+          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].IPv4Address' | grep "10.99.99.";
 
       - name: Test for configured container tags.
         run: |
-          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
 
       - name: Clone the official examples
         run: |
@@ -153,9 +153,9 @@ jobs:
           docker-compose -p drupal9-advanced up -d;
           docker-compose -p drupal9-advanced exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-example-advanced.docker.amazee.io;
-          curl --HEAD http://drupal9-example-advanced.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.docker.amazee.io';
+          curl --HEAD http://drupal9-example-advanced.pygmy.site;
+          curl --HEAD http://drupal9-example-advanced.pygmy.site | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.pygmy.site';
           docker-compose -p drupal9-advanced down;
           docker-compose -p drupal9-advanced rm;
           cd ../../;
@@ -166,9 +166,9 @@ jobs:
           docker-compose -p drupal-base up -d;
           docker-compose -p drupal-base exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-base.docker.amazee.io;
-          curl --HEAD http://drupal9-base.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-base.docker.amazee.io';
+          curl --HEAD http://drupal9-base.pygmy.site;
+          curl --HEAD http://drupal9-base.pygmy.site | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-base.pygmy.site';
           docker-compose -p drupal-base down;
           docker-compose -p drupal-base rm;
           cd ../../;
@@ -179,9 +179,9 @@ jobs:
           docker-compose -p drupal-postgres up -d;
           docker-compose -p drupal-postgres exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-postgres.docker.amazee.io;
-          curl --HEAD http://drupal9-postgres.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-postgres.docker.amazee.io';
+          curl --HEAD http://drupal9-postgres.pygmy.site;
+          curl --HEAD http://drupal9-postgres.pygmy.site | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-postgres.pygmy.site';
           docker-compose -p drupal-postgres down;
           docker-compose -p drupal-postgres rm;
           cd ../../;
@@ -191,9 +191,9 @@ jobs:
           cd lagoon-examples/node-example;
           npm install;
           docker-compose -p node up -d;
-          curl --HEAD http://node.docker.amazee.io;
-          curl --HEAD http://node.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.docker.amazee.io';
+          curl --HEAD http://node.pygmy.site;
+          curl --HEAD http://node.pygmy.site | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.pygmy.site';
           docker-compose -p node down;
           docker-compose -p node rm;
           cd ../../;
@@ -204,9 +204,9 @@ jobs:
           docker-compose -p silverstripe-advanced up -d;
           docker-compose -p silverstripe-advanced exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://ss.docker.amazee.io;
+          curl --HEAD http://ss.pygmy.site;
           # Temporarily, we will omit the failure for the X-LAGOON header.;
-          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON" || true;
+          curl --HEAD http://ss.pygmy.site | grep "X-LAGOON" || true;
           docker-compose -p silverstripe-advanced down;
           docker-compose -p silverstripe-advanced rm;
           cd ../../;
@@ -217,8 +217,8 @@ jobs:
           docker-compose -p silverstripe-simple up -d;
           docker-compose -p silverstripe-simple exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://ss.docker.amazee.io;
-          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON";
+          curl --HEAD http://ss.pygmy.site;
+          curl --HEAD http://ss.pygmy.site | grep "X-LAGOON";
           docker-compose -p silverstripe-simple down;
           docker-compose -p silverstripe-simple rm;
           cd ../../;
@@ -229,9 +229,9 @@ jobs:
           docker-compose -p wordpress-simple up -d;
           docker-compose -p wordpress-simple exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://wordpress-example-simple.docker.amazee.io;
-          curl --HEAD http://wordpress-example-simple.docker.amazee.io | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-example-simple.docker.amazee.io';
+          curl --HEAD http://wordpress-example-simple.pygmy.site;
+          curl --HEAD http://wordpress-example-simple.pygmy.site | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-example-simple.pygmy.site';
           docker-compose -p wordpress-simple down;
           docker-compose -p wordpress-simple rm;
           cd ../../;
@@ -248,11 +248,11 @@ jobs:
 
       - name: Test the down command
         run: |
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml down | grep 'Successfully stopped amazeeio';
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep '\[ \] amazeeio-' | grep 'is not running';
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && false || true;
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml down | grep 'Successfully stopped pygmy';
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep '\[ \] pygmy-' | grep 'is not running';
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container pygmy-' && false || true;
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml up;
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && true || false;
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container pygmy-' && true || false;
 
       - name: Cowsay test
         run: ./pygmy-linux-amd64 --config examples/pygmy.basic.yml up | grep 'holy ship' || true;

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -110,40 +110,40 @@ jobs:
           ./pygmy-linux-amd64 addkey /home/runner/.ssh/id_rsa.pub;
           ./pygmy-linux-amd64 status;
           ./pygmy-linux-amd64 status | grep 'id_rsa';
-          docker run --rm -i --volumes-from pygmy-ssh-agent uselagoon/php-7.4-cli /usr/bin/ssh-add -l | grep 'id_rsa';
+          docker run --rm -i --volumes-from amazeeio-ssh-agent uselagoon/php-7.4-cli /usr/bin/ssh-add -l | grep 'id_rsa';
 
       - name: Resolv file test
         run: |
-          stat /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
-          grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
-          grep "pygmy.site" /usr/lib/systemd/resolved.conf.d/pygmy.site.conf;
+          stat /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
+          grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
+          grep "docker.amazee.io" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
 
       - name: Test the pygmy-network for expected results
         run: |
-          docker network inspect pygmy-network | jq '.[].Name' | grep "pygmy-network";
-          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-haproxy";
-          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-mailhog";
-          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].Name' | grep "pygmy-portainer";
-          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].IPv4Address';
-          docker network inspect pygmy-network | jq '.[].Containers' | jq '.[].IPv4Address' | grep "10.99.99.";
+          docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";
+          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-haproxy";
+          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-mailhog";
+          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-portainer";
+          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address';
+          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address' | grep "10.99.99.";
 
       - name: Test for configured container tags.
         run: |
-          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect pygmy-dnsmasq   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect pygmy-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect pygmy-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect pygmy-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect pygmy-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-dnsmasq   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
+          docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
 
       - name: Clone the official examples
         run: |
@@ -155,9 +155,9 @@ jobs:
           docker-compose -p drupal9-advanced up -d;
           docker-compose -p drupal9-advanced exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-example-advanced.pygmy.site;
-          curl --HEAD http://drupal9-example-advanced.pygmy.site | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.pygmy.site';
+          curl --HEAD http://drupal9-example-advanced.docker.amazee.io;
+          curl --HEAD http://drupal9-example-advanced.docker.amazee.io | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-example-advanced.docker.amazee.io';
           docker-compose -p drupal9-advanced down;
           docker-compose -p drupal9-advanced rm;
           cd ../../;
@@ -168,9 +168,9 @@ jobs:
           docker-compose -p drupal-base up -d;
           docker-compose -p drupal-base exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-base.pygmy.site;
-          curl --HEAD http://drupal9-base.pygmy.site | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-base.pygmy.site';
+          curl --HEAD http://drupal9-base.docker.amazee.io;
+          curl --HEAD http://drupal9-base.docker.amazee.io | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-base.docker.amazee.io';
           docker-compose -p drupal-base down;
           docker-compose -p drupal-base rm;
           cd ../../;
@@ -181,9 +181,9 @@ jobs:
           docker-compose -p drupal-postgres up -d;
           docker-compose -p drupal-postgres exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://drupal9-postgres.pygmy.site;
-          curl --HEAD http://drupal9-postgres.pygmy.site | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-postgres.pygmy.site';
+          curl --HEAD http://drupal9-postgres.docker.amazee.io;
+          curl --HEAD http://drupal9-postgres.docker.amazee.io | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-postgres.docker.amazee.io';
           docker-compose -p drupal-postgres down;
           docker-compose -p drupal-postgres rm;
           cd ../../;
@@ -193,9 +193,9 @@ jobs:
           cd lagoon-examples/node-example;
           npm install;
           docker-compose -p node up -d;
-          curl --HEAD http://node.pygmy.site;
-          curl --HEAD http://node.pygmy.site | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.pygmy.site';
+          curl --HEAD http://node.docker.amazee.io;
+          curl --HEAD http://node.docker.amazee.io | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.docker.amazee.io';
           docker-compose -p node down;
           docker-compose -p node rm;
           cd ../../;
@@ -206,9 +206,9 @@ jobs:
           docker-compose -p silverstripe-advanced up -d;
           docker-compose -p silverstripe-advanced exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://ss.pygmy.site;
+          curl --HEAD http://ss.docker.amazee.io;
           # Temporarily, we will omit the failure for the X-LAGOON header.;
-          curl --HEAD http://ss.pygmy.site | grep "X-LAGOON" || true;
+          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON" || true;
           docker-compose -p silverstripe-advanced down;
           docker-compose -p silverstripe-advanced rm;
           cd ../../;
@@ -219,8 +219,8 @@ jobs:
           docker-compose -p silverstripe-simple up -d;
           docker-compose -p silverstripe-simple exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://ss.pygmy.site;
-          curl --HEAD http://ss.pygmy.site | grep "X-LAGOON";
+          curl --HEAD http://ss.docker.amazee.io;
+          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON";
           docker-compose -p silverstripe-simple down;
           docker-compose -p silverstripe-simple rm;
           cd ../../;
@@ -231,9 +231,9 @@ jobs:
           docker-compose -p wordpress-simple up -d;
           docker-compose -p wordpress-simple exec -T cli composer install;
           sleep 5;
-          curl --HEAD http://wordpress-example-simple.pygmy.site;
-          curl --HEAD http://wordpress-example-simple.pygmy.site | grep "X-LAGOON";
-          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-example-simple.pygmy.site';
+          curl --HEAD http://wordpress-example-simple.docker.amazee.io;
+          curl --HEAD http://wordpress-example-simple.docker.amazee.io | grep "X-LAGOON";
+          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://wordpress-example-simple.docker.amazee.io';
           docker-compose -p wordpress-simple down;
           docker-compose -p wordpress-simple rm;
           cd ../../;
@@ -251,10 +251,10 @@ jobs:
       - name: Test the down command
         run: |
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml down | grep 'Successfully stopped pygmy';
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep '\[ \] pygmy-' | grep 'is not running';
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container pygmy-' && false || true;
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep '\[ \] amazeeio-' | grep 'is not running';
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && false || true;
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml up;
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container pygmy-' && true || false;
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && true || false;
 
       - name: Cowsay test
         run: ./pygmy-linux-amd64 --config examples/pygmy.basic.yml up | grep 'holy ship' || true;

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -118,7 +118,7 @@ jobs:
           grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
           grep "docker.amazee.io" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
 
-      - name: Test the pygmy-network for expected results
+      - name: Test the amazeeio-network for expected results
         run: |
           docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";
           docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-haproxy";
@@ -250,7 +250,7 @@ jobs:
 
       - name: Test the down command
         run: |
-          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml down | grep 'Successfully stopped pygmy';
+          ./pygmy-linux-amd64 --config examples/pygmy.basic.yml down | grep 'Successfully stopped amazeeio';
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep '\[ \] amazeeio-' | grep 'is not running';
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml status | grep 'Running as container amazeeio-' && false || true;
           ./pygmy-linux-amd64 --config examples/pygmy.basic.yml up;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/pygmystack/pygmy)](https://goreportcard.com/report/github.com/pygmystack/pygmy)
 [![GoDoc](https://godoc.org/github.com/pygmystack/pygmy?status.svg)](https://godoc.org/github.com/pygmystack/pygmy)
 
-This is an application written in Go which is a proposed replacement for [Pygmy](https://pygmy.readthedocs.io/en/master/)
+This is an application written in Go which is a proposed replacement for [Pygmy](https://pygmy-readthedocs.io/en/master/)
 currently written in Ruby. The goal is to provide a better cross-platform experience
 for various users running Lagoon, as well as much greater control over configuration
 options via YAML.
@@ -26,8 +26,8 @@ old version is still available if you have installed it. With no Pygmy running,
 you should get "connection refused" when attempting to connect to the local amazee network.
 
 ```
-curl --HEAD http://myproject.docker.amazee.io
-curl: (7) Failed to connect to myproject.docker.amazee.io port 80: Connection refused
+curl --HEAD http://myproject.pygmy.site
+curl: (7) Failed to connect to myproject.pygmy.site port 80: Connection refused
 ```
 
 ## Installation
@@ -43,7 +43,7 @@ configuration to switch out the `haproxy` image for a compatible one if you'd li
 **Works for**: Linux, MacOS & Windows
 
 ```shell
-git clone https://github.com/pygmystack/pygmy.git && cd pygmy;
+git clone https://github.com/pygmystack/pygmy-git && cd pygmy;
 make build;
 cp ./builds/pygmy-darwin /usr/local/bin/pygmy;
 chmod +x /usr/local/bin/pygmy;
@@ -86,7 +86,7 @@ If you have an Amazee Lagoon project running, you can test the web address and
 expect a `HTTP/1.1 200 OK` response.
 
 ```
-$ curl --HEAD http://myproject.docker.amazee.io
+$ curl --HEAD http://myproject.pygmy.site
 HTTP/1.1 200 OK
 Server: openresty
 Content-Type: text/html; charset=UTF-8
@@ -106,7 +106,7 @@ X-Frame-Options: SameOrigin
 If your project is not running you should expect a 503 response:
 
 ```
-$ curl --HEAD http://FUBARNOTINDAHOUSE.docker.amazee.io
+$ curl --HEAD http://FUBARNOTINDAHOUSE.pygmy.site
 HTTP/1.0 503 Service Unavailable
 Cache-Control: no-cache
 Connection: close
@@ -124,7 +124,7 @@ It will use `dind` and your local daemon to walk through several tests which sho
 
 1. First clone the project:
    ```
-   git clone https://github.com/pygmystack/pygmy.git pygmy && cd pygmy
+   git clone https://github.com/pygmystack/pygmy-git pygmy && cd pygmy
    ```
 2. Perform any updates as required.
 3. Clean the environment.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ options via YAML.
 Please see the existing [Pygmy documentation](https://pygmy.readthedocs.io) for more information
 about Pygmy as this is designed to be a drop-in replacement.
 
-## Early testing
+## Making Pygmy always use `docker.amazee.io`
 
-We welcome testers of this tool. You will probably be an existing user of Pygmy who
-can verify the same functionality, or perhaps who has had trouble installing Pygmy in the
-past on Windows.
+To make sure Pygmy always uses the legacy `amazeeio-*` container names and the
+`docker.amazee.io` domain, just set the environment variable `PYGMY_DOMAIN` to
+`docker.amazee.io`
+
+If the `amazeeio-network' is created and ready for use, Pygmy will
+automatically set these variables at runtime. If not, it will now use the
+container names `pygmy-*` and the domain `*.pygmy.site`.
+
+```shell
+echo 'export PYGMY_DOMAIN=docker.amazee.io' >> ~/.bashrc
+```
 
 ## Is Pygmy running?
 
@@ -43,7 +51,7 @@ configuration to switch out the `haproxy` image for a compatible one if you'd li
 **Works for**: Linux, MacOS & Windows
 
 ```shell
-git clone https://github.com/pygmystack/pygmy-git && cd pygmy;
+git clone https://github.com/pygmystack/pygmy.git && cd pygmy;
 make build;
 cp ./builds/pygmy-darwin /usr/local/bin/pygmy;
 chmod +x /usr/local/bin/pygmy;

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -31,7 +31,7 @@ var updateCmd = &cobra.Command{
 	Example: "pygmy update",
 	Short:   "Pulls Docker Images and recreates the Containers",
 	Long: `Pull all images Pygmy uses, as well as any images containing
-the string 'amazeeio', which encompasses all lagoon images.`,
+the string 'pygmy' or 'amazeeio', which encompasses all lagoon images.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		library.Update(c)

--- a/docs/connect_to_mysql_from_external.md
+++ b/docs/connect_to_mysql_from_external.md
@@ -11,7 +11,7 @@ Docker assigns a randomly published port for MySQL during each container start. 
 
 To get the published port via `docker`:
 
-    $ docker port changeme.net.docker.amazee.io
+    $ docker port changeme.net.pygmy.site
     3306/tcp -> 0.0.0.0:32797
 
 Or via `docker-compose` inside a Drupal repository
@@ -23,14 +23,14 @@ Or via `docker-compose` inside a Drupal repository
 
 If you are on Linux and run docker native, you also need to get the IP of the container
 
-    $ docker inspect --format '{{ .NetworkSettings.IPAddress }}' changeme.net.docker.amazee.io
+    $ docker inspect --format '{{ .NetworkSettings.IPAddress }}' changeme.net.pygmy.site
     172.17.0.4
 
 ### Connect to MySQL
 
 |          | Linux                         | OS X                          |
 |----------|-------------------------------|-------------------------------|
-| IP/Host  | IP from container             | `docker.amazee.io`            |
+| IP/Host  | IP from container             | `pygmy.site`                  |
 | Port     | published port from container | published port from container |
 | Username | `drupal`                      | `drupal`                      |
 | Password | `drupal`                      | `drupal`                      |

--- a/docs/customisation/introduction.md
+++ b/docs/customisation/introduction.md
@@ -24,7 +24,7 @@ resolvers:
 # Services is a hashmap of 
 services:
 
-  # The hashmap entry denotes the service name - such as "amazeeio-dnsmasq".
+  # The hashmap entry denotes the service name - such as "pygmy-dnsmasq".
   mycontainer:
 
     # Config is derrived from the Docker API, intended for container configuration.
@@ -59,7 +59,7 @@ services:
         pygmy.discrete: true
 
         # To test an endpoint:
-        pygmy.url: http://mycontainer.docker.amazee.io
+        pygmy.url: http://mycontainer.pygmy.site
 
         # To identify the purpose of a container - this is rather specialised so please ignore.
         pygmy.purpose: sshagent
@@ -77,16 +77,16 @@ services:
       
       # Hashmap value ideally should be the network name - but could be anything.
       # Results may vary, so try what works.
-      amazeeio-network:
+      pygmy-network:
 
         # Every network needs a name.
-        Name: amazeeio-network
+        Name: pygmy-network
 
         # An array of Containers.
         Containers:
 
           # Container name will tell Pygmy to integrate the container of the specified name should be connected to the docker network.
-          Name: amazeeio-haproxy
+          Name: pygmy-haproxy
 
         Labels:
 

--- a/docs/drupal_site_containers.md
+++ b/docs/drupal_site_containers.md
@@ -40,9 +40,9 @@ This is the easier way, you need to be in the same folder where also the `docker
 
 If you want to connect to a container wherever you are right now with your bash:
 
-	docker exec -itu drupal example.com.docker.amazee.io bash
+	docker exec -itu drupal example.com.pygmy.site bash
 
-*Replace `example.com.docker.amazee.io` with the docker container you want to connect to*
+*Replace `example.com.pygmy.site` with the docker container you want to connect to*
 
 ### Drush from your host machine
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 **What `pygmy` will handle for you:**
 
 * Starting the necessary Docker Containers for the amazee.io Drupal Docker Development
-* If on Linux: Adds `nameserver 127.0.0.1` to your `/etc/resolv.conf` file, so that your local Linux can resolve `*.docker.amazee.io` via the dnsmasq container
-* If on Mac with Docker for Mac: Creates the file `/etc/resolver/docker.amazee.io` which tells OS X to forward DNS requests for `*.docker.amazee.io` to the dnsmasq container
+* If on Linux: Adds `nameserver 127.0.0.1` to your `/etc/resolv.conf` file, so that your local Linux can resolve `*.pygmy.site` via the dnsmasq container
+* If on Mac with Docker for Mac: Creates the file `/etc/resolver/pygmy.site` which tells OS X to forward DNS requests for `*.pygmy.site` to the dnsmasq container
 * Tries to add the ssh key in `~/.ssh/id_rsa` to the ssh-agent container (no worries if that is the wrong key, you can add more any time)
 * Starts a local mail Mail Transfer Agent (MTA) in order to test and view mails
 

--- a/docs/local_docker_development.md
+++ b/docs/local_docker_development.md
@@ -52,12 +52,12 @@ It is possible to add mount ssh private keys into Docker containers, but this is
 
 amazee.io implemented a Drupal Docker Development environment which handles all these issues nicely for you. It allows you to:
 
-* Access all sites via the Port 80 or 443 with just different URLs like site1.docker.amazee.io and site2.docker.amazee.io
+* Access all sites via the Port 80 or 443 with just different URLs like site1.pygmy.site and site2.pygmy.site
 * Add your SSH Key once to the system and can forget about it, no need to add it to each container
 
 The environment starts 4 containers:
 
-* [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/) Docker container which will listen on port 53 and resolve all DNS requests from `*.docker.amazee.io` to `127.0.0.1` \(so basically a better way then filling your `/etc/hosts` file by hand\)
+* [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/) Docker container which will listen on port 53 and resolve all DNS requests from `*.pygmy.site` to `127.0.0.1` \(so basically a better way then filling your `/etc/hosts` file by hand\)
 * [amazeeio/haproxy](https://hub.docker.com/r/amazeeio/haproxy/) Docker container which will listen on port 80 and 443. It additionally listens to the Docker socket, realize when you start a new Drupal Container and adapt fully automatically it's haproxy configuration \(thanks to the awesome tool [docker-gen](https://github.com/jwilder/docker-gen)\). It forwards HTTP and HTTPs requests to the correct Drupal Container. With that we can access all Drupal Containers via a single Port.
 * [amazeeio/ssh-agent](https://hub.docker.com/r/amazeeio/ssh-agent/) Docker container which will keeps an ssh-agent at hand for the other Drupal Containers. With that the Drupal Containers do not need to handle ssh-agenting themselves
 * [mailhog/mailhog](https://hub.docker.com/r/mailhog/mailhog/) Docker container which will keeps emails from being sent but allows for you to read and debug message contents.
@@ -69,7 +69,7 @@ The environment starts 4 containers:
                                             |Docker                                                              |
                                             |                                                                    |
                                             |          HAProxy knows which                                       |
-                                            |          *.docker.amazee.io is                                     |
+                                            |          *.pygmy.site is                                           |
                                             |          handled by which container  +---------------------+       |
                                             |                                      |                     |       |
                                             |                              +-------+ Drupal Container 1  <--+    |

--- a/docs/map_addtitional_ports.md
+++ b/docs/map_addtitional_ports.md
@@ -3,7 +3,7 @@
 
 # Map additional ports
 
-As it explained in the [Connect to MySQL](./connect_to_mysql_from_external.md) section, Docker maps MySQL's 3306 port to a random port on docker.amazee.io. This happens because port 3306 is set in the `docker-compose.yml` file:
+As it explained in the [Connect to MySQL](./connect_to_mysql_from_external.md) section, Docker maps MySQL's 3306 port to a random port on pygmy.site. This happens because port 3306 is set in the `docker-compose.yml` file:
 ```
     ports:
       - "3306"
@@ -19,4 +19,4 @@ In this case, to play with Solr queries:
 - add `"8149"` to the `ports` section of `docker-compose.yml` file
 - restart the container with `docker-compose stop && docker-compose up -d`
 - get the port number with `docker-compose port drupal 8149`
-- start playing at http://docker.amazee.io:&lt;PORT_NUMBER&gt;/solr/drupal/admin/
+- start playing at http://pygmy.site:&lt;PORT_NUMBER&gt;/solr/drupal/admin/

--- a/docs/ssh_agent.md
+++ b/docs/ssh_agent.md
@@ -10,7 +10,7 @@ If you need another key, read the documentation of [`pygmy`](linux_pygmy.md) abo
 3. `docker-compose.yml` should have volume inclusion specified for CLI container:
   ```
   volumes_from:
-    - container:amazeeio-ssh-agent
+    - container:pygmy-ssh-agent
   ```
 4. When CLI container starts, the volume is mounted and an entrypoint script adds SHH key into agent.
   @see https://github.com/amazeeio/lagoon/blob/master/images/php/cli/10-ssh-agent.sh

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,19 +39,19 @@ To find such issues, we need to analyze the docker logs, do that via:
 
 
     docker-compose logs
-    Attaching to amazee_io.docker.amazee.io
-    amazee_io.docker.amazee.io | *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
-    amazee_io.docker.amazee.io | *** Running /etc/my_init.d/20_virtual_host_replace.sh...
-    amazee_io.docker.amazee.io | *** Running /etc/rc.local...
-    amazee_io.docker.amazee.io | *** Booting runit daemon...
-    amazee_io.docker.amazee.io | *** Runit started as PID 33
-    amazee_io.docker.amazee.io | tail: cannot open ‘/var/log/nginx/10fe-drupal.error.log’ for reading: No such file or directory
-    amazee_io.docker.amazee.io | tail: cannot open ‘/var/log/nginx/20be-drupal.error.log’ for reading: No such file or directory
-    amazee_io.docker.amazee.io | tail: cannot open ‘/var/log/nginx/error.log’ for reading: No such file or directory
-    amazee_io.docker.amazee.io | tail: cannot open ‘/var/log/nginx/ssl-10fe-drupal.error.log’ for reading: No such file or directory
-    amazee_io.docker.amazee.io | 160502 05:13:44 mysqld_safe Logging to syslog.
-    amazee_io.docker.amazee.io | child (246) Started
-    amazee_io.docker.amazee.io | Child (246) said Child starts
+    Attaching to amazee_io.pygmy.site
+    amazee_io.pygmy.site | *** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
+    amazee_io.pygmy.site | *** Running /etc/my_init.d/20_virtual_host_replace.sh...
+    amazee_io.pygmy.site | *** Running /etc/rc.local...
+    amazee_io.pygmy.site | *** Booting runit daemon...
+    amazee_io.pygmy.site | *** Runit started as PID 33
+    amazee_io.pygmy.site | tail: cannot open ‘/var/log/nginx/10fe-drupal.error.log’ for reading: No such file or directory
+    amazee_io.pygmy.site | tail: cannot open ‘/var/log/nginx/20be-drupal.error.log’ for reading: No such file or directory
+    amazee_io.pygmy.site | tail: cannot open ‘/var/log/nginx/error.log’ for reading: No such file or directory
+    amazee_io..pygmy.site | tail: cannot open ‘/var/log/nginx/ssl-10fe-drupal.error.log’ for reading: No such file or directory
+    amazee_io.pygmy.site | 160502 05:13:44 mysqld_safe Logging to syslog.
+    amazee_io.pygmy.site | child (246) Started
+    amazee_io.pygmy.site | Child (246) said Child starts
 
 Check the latest few lines of code and you probably see the issue.
 Stuck here? Join our Slack at [slack.amazee.io](https://slack.amazee.io) and we help you.
@@ -63,12 +63,12 @@ To see the logs of the shared container started via `pygmy`, first display all d
     docker ps
 
     CONTAINER ID        IMAGE                         COMMAND                  CREATED             STATUS              PORTS                                      NAMES
-    9e27b9eadc67        amazeeio/drupal:php70-basic   "/sbin/my_init"          5 minutes ago       Up 5 minutes        80/tcp, 443/tcp, 0.0.0.0:32782->3306/tcp   amazee_io.docker.amazee.io
-    5ce655cd369f        andyshinn/dnsmasq:2.75        "dnsmasq -k -A /docke"   24 minutes ago      Up 24 minutes       0.0.0.0:53->53/tcp, 0.0.0.0:53->53/udp     amazeeio-dnsmasq
-    124b3919e89a        amazeeio/ssh-agent            "/run.sh ssh-agent"      24 minutes ago      Up 24 minutes                                                  amazeeio-ssh-agent
-    93eb7a384640        amazeeio/haproxy              "/app/docker-entrypoi"   24 minutes ago      Up 24 minutes       0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   amazeeio-haproxy
+    9e27b9eadc67        amazeeio/drupal:php70-basic   "/sbin/my_init"          5 minutes ago       Up 5 minutes        80/tcp, 443/tcp, 0.0.0.0:32782->3306/tcp   pygmy.pygmy.site
+    5ce655cd369f        andyshinn/dnsmasq:2.75        "dnsmasq -k -A /docke"   24 minutes ago      Up 24 minutes       0.0.0.0:53->53/tcp, 0.0.0.0:53->53/udp     pygmy-dnsmasq
+    124b3919e89a        amazeeio/ssh-agent            "/run.sh ssh-agent"      24 minutes ago      Up 24 minutes                                                  pygmy-ssh-agent
+    93eb7a384640        amazeeio/haproxy              "/app/docker-entrypoi"   24 minutes ago      Up 24 minutes       0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp   pygmy-haproxy
 
-You can see three containers that have names with starting `amazeeio-` these are the shared containers.
+You can see three containers that have names with starting `pygmy-` these are the shared containers.
 
 You can view each container's logs via:
 
@@ -90,7 +90,7 @@ If that does not resolve the issue, restart pygmy
 pygmy restart -d
 ```
 
-### I get an error like `Conflict. The name "/amazee_io.docker.amazee.io" is already in use by container`
+### I get an error like `Conflict. The name "/pygmy.pygmy.site" is already in use by container`
 
 It happened to all of us, you remove a local `docker-compose.yml` file, recreate it and now during `docker-compose up -d`, docker yells at you and tells you this container exists already.
 
@@ -103,15 +103,15 @@ The easiest way would be to just give your new container another name, but there
         docker ps
 
         CONTAINER ID        IMAGE                         COMMAND                  CREATED             STATUS              PORTS                                      NAMES
-        9e27b9eadc67        amazeeio/drupal:php70-basic   "/sbin/my_init"          10 minutes ago      Up 10 minutes       80/tcp, 443/tcp, 0.0.0.0:32782->3306/tcp   amazee_io.docker.amazee.io
+        9e27b9eadc67        amazeeio/drupal:php70-basic   "/sbin/my_init"          10 minutes ago      Up 10 minutes       80/tcp, 443/tcp, 0.0.0.0:32782->3306/tcp   amazee_io..pygmy.site
 
 2. Stop the container
 
-        docker stop amazee_io.docker.amazee.io
+        docker stop amazee_io.pygmy.site
 
 3. Remove the container with it's volumes:
 
-        docker rm -v amazee_io.docker.amazee.io
+        docker rm -v amazee_io.pygmy.site
 
 #### Remove all containers and all volumes
 
@@ -153,34 +153,34 @@ If you need to free up some disk space, you can do this:
 If during the start of Docker containers you see an error like that:
 
     docker: Error response from daemon: driver failed programming external connectivity on endpoint
-    amazeeio-haproxy (654d1f1c17b0f7304570a763e1017808b214b81648045a5c64ed6a395daeec92):
+    pygmy-haproxy (654d1f1c17b0f7304570a763e1017808b214b81648045a5c64ed6a395daeec92):
     Bind for 0.0.0.0:443 failed: port is already allocated.
 
 This means that another service (can be another Docker container, or in case of Linux based systems another service like an installed nginx) is already using this Port.
 
 You should stop this service or Docker container first.
 
-### I get an error like `Service "drupal" mounts volumes from "amazeeio-ssh-agent", which is not the name of a service or container.`
+### I get an error like `Service "drupal" mounts volumes from "pygmy-ssh-agent", which is not the name of a service or container.`
 
 This can happen when you start a Drupal Container via `docker-compose up -d` and the pygmy service has stopped
 
     docker-compose up -d
-    ERROR: Service "drupal" mounts volumes from "amazeeio-ssh-agent", which is not the name of a service or container.
+    ERROR: Service "drupal" mounts volumes from "pygmy-ssh-agent", which is not the name of a service or container.
 
 The Drupal Containers are depending on the `ssh-agent` shared Docker container (this is in order to have shared ssh-keys) and somehow this container is missing.
 
-Try to restart `pygmy` , this will create the `ssh-agent` container with the name `amazeeio-ssh-agent` and then try again.
+Try to restart `pygmy` , this will create the `ssh-agent` container with the name `pygmy-ssh-agent` and then try again.
 
 ### Working Offline
 
-Amazeeio uses a remote DNS server to resolve your `*.docker.amazee.io` addresses which means if you don't have an internet connection you are not going to be able to get to your site. However, you can use your `hosts` file in this scenario. This file is typically located at `/etc/hosts` on Linux and macOS and `C:\Windows\System32\Drivers\etc\host` on Windows. You will need administrative privileges to edit this file.
+Amazeeio uses a remote DNS server to resolve your `*.pygmy.site` addresses which means if you don't have an internet connection you are not going to be able to get to your site. However, you can use your `hosts` file in this scenario. This file is typically located at `/etc/hosts` on Linux and macOS and `C:\Windows\System32\Drivers\etc\host` on Windows. You will need administrative privileges to edit this file.
 
 If you are unfamiliar with this process, follow this tutorial at [How-To Geek](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/).
 
 ### Host entry if using pygmy
 
 ```bash
-127.0.0.1 awesomesauce.docker.amazee.io
+127.0.0.1 awesomesauce.pygmy.site
 ```
 
 
@@ -190,7 +190,7 @@ If you are running the Windows VM in VirtualBox, you can configure it to use the
 
     VBoxManage modifyvm "IE11 - Win10" --natdnshostresolver1 on
 
-Replace `"IE11 - Win10"` with the name of your VM. This will allow the VM to resolve and connect directly to your `http://*.docker.amazee.io` services running in pygmy.
+Replace `"IE11 - Win10"` with the name of your VM. This will allow the VM to resolve and connect directly to your `http://*.pygmy.site` services running in pygmy.
 
 #### For pygmy
 
@@ -200,9 +200,9 @@ To get the gateway IP, run `ipconfig` in Windows terminal, and search for `Defau
 
 Example `hosts` file contents:
 
-    10.0.2.2 my-local-website.com.docker.amazee.io
+    10.0.2.2 my-local-website.com.pygmy.site
 
-### I get an error like `no such service: amazeeio-ssh-agent` when using `docker-compose up -d` even after pygmy started fine
+### I get an error like `no such service: pygmy-ssh-agent` when using `docker-compose up -d` even after pygmy started fine
 
 Restart pygmy and make sure that pygmy could start the ssh-agent container.
 
@@ -211,7 +211,7 @@ Restart pygmy and make sure that pygmy could start the ssh-agent container.
 
 You could see a message like this:
 
-    [*] ssh-agent: Running as docker container amazeeio-ssh-agent, loaded keys:
+    [*] ssh-agent: Running as docker container pygmy-ssh-agent, loaded keys:
 
 #### Docker Desktop users
 
@@ -244,9 +244,9 @@ If that does not help, try and restart other services, in this order:
 
 If during starting of `pygmy` you see an error like that:
 
-        Error response from daemon: driver failed programming external connectivity on endpoint amazeeio-dnsmasq:
+        Error response from daemon: driver failed programming external connectivity on endpoint pygmy-dnsmasq:
         Error starting userland proxy: listen tcp 0.0.0.0:53: bind: address already in use
-        Error: failed to start containers: amazeeio-dnsmasq
+        Error: failed to start containers: pygmy-dnsmasq
 
 You are probably on Ubuntu and the by default started DNS server by Ubuntu conflicts with the one we provide with `pygmy`. The resolution depends on Ubuntu version.
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -8,11 +8,11 @@ Use the [same instructions](./installation.md) to update Pygmy as to install it.
 
 If you see anything unexpected after upgrading, the recommended advice is to clean up the environment _and_ remove the docker network.
 
-Any applications which use the network `amazeeio-network` such as a docker-compose Drupal project - should not be running. You can alternatively run `docker network rm amazeeio-network --force`.
+Any applications which use the network `pygmy-network` such as a docker-compose Drupal project - should not be running. You can alternatively run `docker network rm pygmy-network --force`.
 
 ```console
 $ pygmy clean
-$ docker network rm amazeeio-network
+$ docker network rm pygmy-network
 ```
 
 ## Update Docker Containers with `pygmy`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,15 +57,15 @@ Run `pygmy status` and `pygmy` will tell you how it feels right now and which ss
 
     pygmy status
 
-    [*] amazeeio-ssh-agent: Running as container amazeeio-ssh-agent
-    [*] mailhog.docker.amazee.io: Running as container mailhog.docker.amazee.io
-    [*] amazeeio-haproxy: Running as container amazeeio-haproxy
-    [*] amazeeio-dnsmasq: Running as container amazeeio-dnsmasq
-    [*] amazeeio-haproxy is connected to network amazeeio-network
+    [*] pygmy-ssh-agent: Running as container pygmy-ssh-agent
+    [*] mailhog.pygmy.site: Running as container mailhog.pygmy.site
+    [*] pygmy-haproxy: Running as container pygmy-haproxy
+    [*] pygmy-dnsmasq: Running as container pygmy-dnsmasq
+    [*] pygmy-haproxy is connected to network pygmy-network
     [*] Resolv MacOS Resolver is properly connected
     �ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDNxWpKZcU/D+t7ToRGPNEXbvojrFtxKH99ZuaOJ7cs9KurVJyiEHyBEUZAPt0j9SO5yzdVEM//rVoZIwZeypW9C7CYgTpRoA/k1BnE1xvtoQT+528GmjQG542NBFo2KdO+LWqx19kClvoN7haGDtYKbS6MWUYEwD0ey69cquFDKC+A5NKx3z065gn9UZqLIeXjHCJ+v5PCSWXL3CFn57UlN824j1OFAECrjfNNfFEVmDJqa2Da6o9DhN+W1wyZJCklRPCiRlK5m3p9x1ClPKALUGQ0hvpjz36QSsXqS88MJPHsZvsv2PuW6xXNW8PSBCHcK6no5lYV/4hk8jcDQd2P6dpwvDiti+bTcfDH3jrVNqFati7ku37xIc3jWGn7CkCpMy008ai4kFMq2W2w6gOy0HncQ7z8AE8BdndxyEFYCLJviWOjW1SjSesPJpc9dxgmSmp/2qa6u0UZzFFHxJklIHepJAvcoHghs5Te2oMHwriRdpKqXiW+eJyudWCOzEeJljr73/Caft+CgZ7+kmmiy0hlqVAD6xkyBsuEF8+MdONfBHarpY8qZdLehavGd0DJW36nDnPvefDxoidJ0qYtjF8ElpNkeguAnsUFEwHkoc3Ur/NDcrkdGTKS8wb5AtkdwbDOCQTR00ABfAcYUFwOAvXodoQLrvm2ibp5l7/Y/Q== user@localhost
-     - http://mailhog.docker.amazee.io (mailhog.docker.amazee.io)
-     - http://docker.amazee.io/stats (amazeeio-haproxy)
+     - http://mailhog.pygmy.site (mailhog.pygmy.site)
+     - http://pygmy.site/stats (pygmy-haproxy)
 
 ## `pygmy down` vs `pygmy clean`
 
@@ -77,6 +77,6 @@ If you like to cleanup though, use `pygmy clean` to kill and remove all of the D
 
 ## Access HAProxy statistic page and logs  
 
-HAProxy service has statistics web page already enabled. To access the page, just point the browser to [http://docker.amazee.io/stats](http://docker.amazee.io/stats).  
+HAProxy service has statistics web page already enabled. To access the page, just point the browser to [http://pygmy.site/stats](http://pygmy.site/stats).  
 
-To watch at haproxy container logs, use the `docker logs amazeeio-haproxy` command with standard `docker logs` options like `-f` to follow.
+To watch at haproxy container logs, use the `docker logs pygmy-haproxy` command with standard `docker logs` options like `-f` to follow.

--- a/examples/pygmy.basic.yml
+++ b/examples/pygmy.basic.yml
@@ -1,8 +1,12 @@
+---
+prefix: amazeeio
+domain: docker.amazee.io
 services:
 
   amazeeio-dnsmasq:
     Config:
       Labels:
+        - pygmy.name: custom-dnsmasq
         - pygmy.hocuspocus: 42
         - pygmy.abracadabra: true
         - pygmy.opensesame: correct
@@ -10,6 +14,7 @@ services:
   amazeeio-haproxy:
     Config:
       Labels:
+        - pygmy.name: custom-haproxy
         - pygmy.hocuspocus: 42
         - pygmy.abracadabra: true
         - pygmy.opensesame: correct
@@ -17,6 +22,7 @@ services:
   amazeeio-mailhog:
     Config:
       Labels:
+        - pygmy.name: custom-mailhog
         - pygmy.hocuspocus: 42
         - pygmy.abracadabra: true
         - pygmy.opensesame: correct
@@ -42,7 +48,7 @@ services:
         - "AMAZEEIO_HTTP_PORT=9000"
       Labels:
         - pygmy.enable: true
-        - pygmy.name: amazeeio-portainer
+        - pygmy.name: custom-portainer
         - pygmy.network: amazeeio-network
         - pygmy.weight: 23
         - pygmy.url: http://portainer.docker.amazee.io
@@ -61,7 +67,7 @@ services:
         9000/tcp:
           - HostPort: 8100
 
-  pygmy-cowsay:
+  custom-cowsay:
     Config:
       Image: mbentley/cowsay
       Cmd:

--- a/examples/pygmy.complex.yml
+++ b/examples/pygmy.complex.yml
@@ -1,5 +1,7 @@
 ---
-
+prefix: amazeeio
+domain: docker.amazee.io
+defaults: true
 services:
 
   amazeeio-haproxy:
@@ -16,7 +18,7 @@ services:
     Config:
       Labels:
         - pygmy.enable: true
-        - pygmy.name: amazeeio-mailhog
+        - pygmy.name: unofficial-mailhog
         - pygmy.network: amazeeio-network
         - traefik.enable: true
         - traefik.port: 80

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func setup(t *testing.T, config *config) {
 		downCmd = fmt.Sprintf("/builds/%v down --config %v", binaryReference, config.configpath)
 	}
 
-	time.Sleep(5)
+	time.Sleep(5 * time.Second)
 
 	Convey("Pygmy Application Test: "+config.name, t, func() {
 

--- a/service/dnsmasq/dnsmasq.go
+++ b/service/dnsmasq/dnsmasq.go
@@ -22,7 +22,7 @@ func New(c *model.Params) model.Service {
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-dnsmasq",
+				"pygmy.name":     fmt.Sprintf("%s-dnsmasq", c.Prefix),
 				"pygmy.weight":   "13",
 			},
 		},

--- a/service/dnsmasq/dnsmasq_test.go
+++ b/service/dnsmasq/dnsmasq_test.go
@@ -16,13 +16,13 @@ func Example() {
 
 func Test(t *testing.T) {
 	Convey("DNSMasq: Field equality tests...", t, func() {
-		obj := dnsmasq.New(&model.Params{Domain: "docker.amazee.io"})
+		obj := dnsmasq.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 
 		So(obj.Config.Image, ShouldEqual, "pygmystack/dnsmasq")
-		So(fmt.Sprint(obj.Config.Cmd), ShouldEqual, fmt.Sprint([]string{"--log-facility=-", "-A", "/docker.amazee.io/127.0.0.1"}))
+		So(fmt.Sprint(obj.Config.Cmd), ShouldEqual, fmt.Sprint([]string{"--log-facility=-", "-A", "/pygmy.site/127.0.0.1"}))
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
-		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-dnsmasq")
+		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "pygmy-dnsmasq")
 		So(obj.Config.Labels["pygmy.weight"], ShouldEqual, "13")
 		So(obj.HostConfig.AutoRemove, ShouldBeFalse)
 		So(fmt.Sprint(obj.HostConfig.CapAdd), ShouldEqual, fmt.Sprint([]string{"NET_ADMIN"}))

--- a/service/haproxy/haproxy.go
+++ b/service/haproxy/haproxy.go
@@ -17,8 +17,8 @@ func New(c *model.Params) model.Service {
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-haproxy",
-				"pygmy.network":  "amazeeio-network",
+				"pygmy.name":     fmt.Sprintf("%s-haproxy", c.Prefix),
+				"pygmy.network":  fmt.Sprintf("%s-network", c.Prefix),
 				"pygmy.url":      fmt.Sprintf("http://%s/stats", c.Domain),
 				"pygmy.weight":   "14",
 			},

--- a/service/haproxy/haproxy_test.go
+++ b/service/haproxy/haproxy_test.go
@@ -17,14 +17,14 @@ func Example() {
 
 func Test(t *testing.T) {
 	Convey("HAProxy: Field equality tests...", t, func() {
-		obj := haproxy.New(&model.Params{Domain: "docker.amazee.io"})
+		obj := haproxy.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 		objPorts := haproxy.NewDefaultPorts()
 		So(obj.Config.Image, ShouldEqual, "pygmystack/haproxy")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
-		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-haproxy")
-		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "amazeeio-network")
-		So(obj.Config.Labels["pygmy.url"], ShouldEqual, "http://docker.amazee.io/stats")
+		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "pygmy-haproxy")
+		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "pygmy-network")
+		So(obj.Config.Labels["pygmy.url"], ShouldEqual, "http://pygmy.site/stats")
 		So(obj.Config.Labels["pygmy.weight"], ShouldEqual, "14")
 		So(obj.HostConfig.AutoRemove, ShouldBeFalse)
 		So(fmt.Sprint(obj.HostConfig.Binds), ShouldEqual, fmt.Sprint([]string{"/var/run/docker.sock:/tmp/docker.sock"}))

--- a/service/interface/docker/docker.go
+++ b/service/interface/docker/docker.go
@@ -153,11 +153,11 @@ func DockerPull(image string) (string, error) {
 	}
 
 	if event != nil {
-		if strings.Contains(event.Status, fmt.Sprint("Downloaded newer image")) {
+		if strings.Contains(event.Status, "Downloaded newer image") {
 			return fmt.Sprintf("Successfully pulled %v", image), nil
 		}
 
-		if strings.Contains(event.Status, fmt.Sprint("Image is up to date")) {
+		if strings.Contains(event.Status, "Image is up to date") {
 			return fmt.Sprintf("Image %v is up to date", image), nil
 		}
 	}

--- a/service/interface/types.go
+++ b/service/interface/types.go
@@ -12,6 +12,8 @@ import (
 type Params struct {
 	// Domain is the target domain for Pygmy to use.
 	Domain string
+	// Prefix is the service prefix
+	Prefix string
 }
 
 // DockerService is the requirements for a Docker container to be compatible.

--- a/service/library/clean.go
+++ b/service/library/clean.go
@@ -2,6 +2,7 @@ package library
 
 import (
 	"fmt"
+	model "github.com/pygmystack/pygmy/service/interface"
 	"strings"
 
 	. "github.com/logrusorgru/aurora"
@@ -62,6 +63,6 @@ func Clean(c Config) {
 	}
 
 	for _, resolver := range c.Resolvers {
-		resolver.Clean()
+		resolver.Clean(&model.Params{Domain: c.Domain, Prefix: c.Prefix})
 	}
 }

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -29,6 +29,11 @@ type Config struct {
 	// Networks is for network configuration
 	Networks map[string]types.NetworkResource `yaml:"networks"`
 
+	// Prefix defines what services and networks should be associated to.
+	// This is to easily rename all the services by reference rather than
+	// hard-coding prefix values.
+	Prefix string `yaml:"prefix"`
+
 	// NoDefaults will prevent default configuration items.
 	Defaults bool
 
@@ -55,6 +60,9 @@ func mergeService(destination model.Service, src *model.Service) (*model.Service
 
 func getService(s model.Service, c model.Service) model.Service {
 	Service, _ := mergeService(s, &c)
+	if Service == nil {
+		return model.Service{}
+	}
 	return *Service
 }
 

--- a/service/library/setup_test.go
+++ b/service/library/setup_test.go
@@ -1,6 +1,7 @@
 package library_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pygmystack/pygmy/service/library"
@@ -11,7 +12,7 @@ func TestSortedServices(t *testing.T) {
 	c := &library.Config{}
 	library.Setup(c)
 	c.SortedServices = library.GetServicesSorted(c)
-	if c.SortedServices[0] != "amazeeio-ssh-agent" {
+	if !strings.HasSuffix(c.SortedServices[0], "-ssh-agent") {
 		t.Fail()
 	}
 	for _, v := range c.SortedServices {

--- a/service/library/sshkeyadd.go
+++ b/service/library/sshkeyadd.go
@@ -80,7 +80,7 @@ func SshKeyAdd(c Config, key string, passcode string) error {
 					color.Print(aurora.Green(fmt.Sprintf("Successfully added SSH key %v to agent\n", key)))
 				}
 				if strings.Contains(line, "Enter passphrase for") {
-					color.Print(aurora.Yellow(fmt.Sprintf("Warning: Passphrase protected SSH keys are not currently supported, the key will not be added.\n")))
+					color.Print(aurora.Yellow("Warning: Passphrase protected SSH keys are not currently supported, the key will not be added.\n"))
 				}
 			}
 

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -123,7 +123,7 @@ func Status(c Config) {
 	containers, _ := docker.DockerContainerList()
 	var urls []string
 	for _, container := range containers {
-		if container.State == "running" && !strings.Contains(fmt.Sprint(container.Names), "amazeeio") {
+		if container.State == "running" && !strings.Contains(fmt.Sprint(container.Names), "pygmy") {
 			obj, _ := docker.DockerInspect(container.ID)
 			vars := obj.Config.Env
 			for _, v := range vars {

--- a/service/library/up.go
+++ b/service/library/up.go
@@ -48,7 +48,7 @@ func Up(c Config) {
 	// Maps are... bad for predictable sequencing.
 	// Look over the sorted slice and start them in
 	// alphabetical order - so that one can configure
-	// an ssh-agent like amazeeio-ssh-agent.
+	// an ssh-agent like pygmy-ssh-agent.
 	for _, s := range c.SortedServices {
 		service := c.Services[s]
 		enabled, _ := service.GetFieldBool("enable")
@@ -82,7 +82,7 @@ func Up(c Config) {
 		}
 
 		// If one or more agent was found:
-		if purpose == "sshagent" {
+		if enabled && purpose == "sshagent" {
 			agentPresent = true
 		}
 	}
@@ -154,7 +154,7 @@ func Up(c Config) {
 	containers, _ := docker.DockerContainerList()
 	var urls []string
 	for _, container := range containers {
-		if container.State == "running" && !strings.Contains(fmt.Sprint(container.Names), "amazeeio") {
+		if container.State == "running" && strings.Contains(fmt.Sprint(container.Names), c.Prefix) {
 			obj, _ := docker.DockerInspect(container.ID)
 			vars := obj.Config.Env
 			for _, v := range vars {

--- a/service/mailhog/mailhog.go
+++ b/service/mailhog/mailhog.go
@@ -29,8 +29,8 @@ func New(c *model.Params) model.Service {
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-mailhog",
-				"pygmy.network":  "amazeeio-network",
+				"pygmy.name":     fmt.Sprintf("%s-mailhog", c.Prefix),
+				"pygmy.network":  fmt.Sprintf("%s-network", c.Prefix),
 				"pygmy.url":      fmt.Sprintf("http://mailhog.%s", c.Domain),
 				"pygmy.weight":   "15",
 			},

--- a/service/mailhog/mailhog_test.go
+++ b/service/mailhog/mailhog_test.go
@@ -17,17 +17,17 @@ func Example() {
 
 func Test(t *testing.T) {
 	Convey("MailHog: Field equality tests...", t, func() {
-		obj := mailhog.New(&model.Params{Domain: "docker.amazee.io"})
+		obj := mailhog.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 		objPorts := mailhog.NewDefaultPorts()
 		So(obj.Config.User, ShouldEqual, "0")
 		So(obj.Config.Image, ShouldEqual, "pygmystack/mailhog")
 		So(fmt.Sprint(obj.Config.ExposedPorts), ShouldEqual, fmt.Sprint(nat.PortSet{"80/tcp": struct{}{}, "1025/tcp": struct{}{}, "8025/tcp": struct{}{}}))
-		So(fmt.Sprint(obj.Config.Env), ShouldEqual, fmt.Sprint([]string{"MH_UI_BIND_ADDR=0.0.0.0:80", "MH_API_BIND_ADDR=0.0.0.0:80", "AMAZEEIO=AMAZEEIO", "AMAZEEIO_URL=mailhog.docker.amazee.io"}))
+		So(fmt.Sprint(obj.Config.Env), ShouldEqual, fmt.Sprint([]string{"MH_UI_BIND_ADDR=0.0.0.0:80", "MH_API_BIND_ADDR=0.0.0.0:80", "AMAZEEIO=AMAZEEIO", "AMAZEEIO_URL=mailhog.pygmy.site"}))
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
-		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-mailhog")
-		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "amazeeio-network")
-		So(obj.Config.Labels["pygmy.url"], ShouldEqual, "http://mailhog.docker.amazee.io")
+		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "pygmy-mailhog")
+		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "pygmy-network")
+		So(obj.Config.Labels["pygmy.url"], ShouldEqual, "http://mailhog.pygmy.site")
 		So(obj.Config.Labels["pygmy.weight"], ShouldEqual, "15")
 		So(obj.HostConfig.AutoRemove, ShouldBeFalse)
 		So(obj.HostConfig.PortBindings, ShouldEqual, nil)

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -1,15 +1,17 @@
 package network
 
 import (
+	"fmt"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	model "github.com/pygmystack/pygmy/service/interface"
 )
 
 // New will generate the defaults for the Docker network.
 // If configuration is provided this will not be used at all.
-func New() types.NetworkResource {
+func New(c *model.Params) types.NetworkResource {
 	return types.NetworkResource{
-		Name: "amazeeio-network",
+		Name: fmt.Sprintf("%s-network", c.Prefix),
 		IPAM: network.IPAM{
 			Driver:  "",
 			Options: nil,
@@ -21,7 +23,7 @@ func New() types.NetworkResource {
 			},
 		},
 		Labels: map[string]string{
-			"pygmy.name": "amazeeio-network",
+			"pygmy.name": fmt.Sprintf("%s-network", c.Prefix),
 		},
 	}
 }

--- a/service/network/network_test.go
+++ b/service/network/network_test.go
@@ -3,6 +3,7 @@ package network_test
 import (
 	"fmt"
 	"github.com/docker/docker/api/types/network"
+	model "github.com/pygmystack/pygmy/service/interface"
 	"testing"
 
 	n "github.com/pygmystack/pygmy/service/network"
@@ -10,16 +11,16 @@ import (
 )
 
 func Example() {
-	n.New()
+	n.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 }
 
 func Test(t *testing.T) {
 	Convey("Network: Field equality tests...", t, func() {
-		obj := n.New()
-		So(obj.Name, ShouldEqual, "amazeeio-network")
+		obj := n.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
+		So(obj.Name, ShouldEqual, "pygmy-network")
 		So(obj.IPAM.Driver, ShouldEqual, "")
 		So(obj.IPAM.Options, ShouldEqual, nil)
 		So(fmt.Sprint(obj.IPAM.Config), ShouldEqual, fmt.Sprint([]network.IPAMConfig{{Subnet: "10.99.99.0/24", Gateway: "10.99.99.1"}}))
-		So(fmt.Sprint(obj.Labels), ShouldEqual, fmt.Sprint(map[string]string{"pygmy.name": "amazeeio-network"}))
+		So(fmt.Sprint(obj.Labels), ShouldEqual, fmt.Sprint(map[string]string{"pygmy.name": "pygmy-network"}))
 	})
 }

--- a/service/resolv/resolv.go
+++ b/service/resolv/resolv.go
@@ -60,7 +60,7 @@ func (resolv Resolv) Configure(c *model.Params) {
 
 			// Create the file if it doesn't exist.
 			if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-				if tmpFile, err = ioutil.TempFile("", "pygmy-"); err != nil {
+				if tmpFile, err = ioutil.TempFile("", fmt.Sprintf("%s-", c.Prefix)); err != nil {
 					fmt.Println(err)
 				}
 				if err = os.Chmod(tmpFile.Name(), 0777); err != nil {
@@ -87,7 +87,7 @@ func (resolv Resolv) Configure(c *model.Params) {
 						fmt.Println("/bin/sh", "-c", "cat "+fullPath)
 					}
 
-					if tmpFile, err = ioutil.TempFile("", "pygmy-"); err != nil {
+					if tmpFile, err = ioutil.TempFile("", fmt.Sprintf("%s-", c.Prefix)); err != nil {
 						fmt.Println(err)
 					} else {
 						if err = os.Chmod(tmpFile.Name(), 0777); err != nil {
@@ -129,7 +129,7 @@ func (resolv Resolv) Configure(c *model.Params) {
 
 // Clean will cleanup the resolv file configured to the system and run some
 // cleanup commands which were ran at the end of resolv.Configure on MacOS.
-func (resolv Resolv) Clean() {
+func (resolv Resolv) Clean(c *model.Params) {
 
 	fullPath := fmt.Sprintf("%v%v%v", resolv.Folder, string(os.PathSeparator), resolv.File)
 	if runtime.GOOS == "linux" {
@@ -141,7 +141,7 @@ func (resolv Resolv) Clean() {
 			} else {
 				if strings.Contains(string(cmdOut), resolv.Data) {
 					newFile := strings.Replace(string(cmdOut), resolv.Data, "", -1)
-					if tmpFile, err := ioutil.TempFile("", "pygmy-"); err != nil {
+					if tmpFile, err := ioutil.TempFile("", fmt.Sprintf("%s-", c.Prefix)); err != nil {
 						fmt.Println(err)
 					} else {
 						if err = os.Chmod(tmpFile.Name(), 0777); err != nil {

--- a/service/resolv/resolvWin.go
+++ b/service/resolv/resolvWin.go
@@ -49,7 +49,7 @@ func run(args []string) ([]byte, error) {
 
 }
 
-func (resolv Resolv) Clean() {
+func (resolv Resolv) Clean(c *model.Params) {
 	_, error := run([]string{"Clear-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters -Name Domain"})
 	if error != nil {
 		fmt.Println(error.Error())

--- a/service/ssh/agent/ssh_agent.go
+++ b/service/ssh/agent/ssh_agent.go
@@ -15,15 +15,15 @@ import (
 )
 
 // New will provide the standard object for the SSH agent container.
-func New() model.Service {
+func New(c *model.Params) model.Service {
 	return model.Service{
 		Config: container.Config{
 			Image: "pygmystack/ssh-agent",
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-ssh-agent",
-				"pygmy.network":  "amazeeio-network",
+				"pygmy.name":     fmt.Sprintf("%s-ssh-agent", c.Prefix),
+				"pygmy.network":  fmt.Sprintf("%s-network", c.Prefix),
 				"pygmy.output":   "false",
 				"pygmy.purpose":  "sshagent",
 				"pygmy.weight":   "10",

--- a/service/ssh/agent/ssh_agent_test.go
+++ b/service/ssh/agent/ssh_agent_test.go
@@ -25,13 +25,13 @@ func TestExampleSearch(t *testing.T) {
 
 func Test(t *testing.T) {
 	Convey("SSH Agent: Field equality tests...", t, func() {
-		obj := agent.New()
+		obj := agent.New(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 		So(obj.Config.Image, ShouldEqual, "pygmystack/ssh-agent")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.output"], ShouldEqual, "false")
-		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-ssh-agent")
-		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "amazeeio-network")
+		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "pygmy-ssh-agent")
+		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "pygmy-network")
 		So(obj.Config.Labels["pygmy.purpose"], ShouldEqual, "sshagent")
 		So(obj.Config.Labels["pygmy.weight"], ShouldEqual, "10")
 		So(obj.HostConfig.AutoRemove, ShouldBeFalse)

--- a/service/ssh/key/ssh_addkey.go
+++ b/service/ssh/key/ssh_addkey.go
@@ -4,6 +4,7 @@
 package key
 
 import (
+	"fmt"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 
@@ -11,15 +12,15 @@ import (
 )
 
 // NewAdder will provide the standard object for the SSH key adder container.
-func NewAdder() model.Service {
+func NewAdder(c *model.Params) model.Service {
 	return model.Service{
 		Config: container.Config{
 			Image: "pygmystack/ssh-agent",
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-ssh-agent-add-key",
-				"pygmy.network":  "amazeeio-network",
+				"pygmy.name":     fmt.Sprintf("%s-ssh-agent-add-key", c.Prefix),
+				"pygmy.network":  fmt.Sprintf("%s-network", c.Prefix),
 				"pygmy.discrete": "true",
 				"pygmy.output":   "false",
 				"pygmy.purpose":  "addkeys",
@@ -29,7 +30,7 @@ func NewAdder() model.Service {
 		HostConfig: container.HostConfig{
 			AutoRemove:  false,
 			IpcMode:     "private",
-			VolumesFrom: []string{"amazeeio-ssh-agent"},
+			VolumesFrom: []string{fmt.Sprintf("%s-ssh-agent", c.Prefix)},
 		},
 		NetworkConfig: network.NetworkingConfig{},
 	}

--- a/service/ssh/key/ssh_addkey_test.go
+++ b/service/ssh/key/ssh_addkey_test.go
@@ -2,6 +2,7 @@ package key_test
 
 import (
 	"fmt"
+	model "github.com/pygmystack/pygmy/service/interface"
 	"testing"
 
 	"github.com/pygmystack/pygmy/service/ssh/key"
@@ -14,18 +15,18 @@ import (
 
 func TestAdd(t *testing.T) {
 	Convey("SSH Key Adder: Field equality tests...", t, func() {
-		obj := key.NewAdder()
+		obj := key.NewAdder(&model.Params{Domain: "pygmy.site", Prefix: "pygmy"})
 		So(obj.Config.Image, ShouldEqual, "pygmystack/ssh-agent")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.output"], ShouldEqual, "false")
 		So(obj.Config.Labels["pygmy.discrete"], ShouldEqual, "true")
-		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-ssh-agent-add-key")
-		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "amazeeio-network")
+		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "pygmy-ssh-agent-add-key")
+		So(obj.Config.Labels["pygmy.network"], ShouldEqual, "pygmy-network")
 		So(obj.Config.Labels["pygmy.purpose"], ShouldEqual, "addkeys")
 		So(obj.Config.Labels["pygmy.weight"], ShouldEqual, "31")
 		So(obj.HostConfig.AutoRemove, ShouldBeFalse)
 		So(obj.HostConfig.IpcMode, ShouldEqual, "private")
-		So(fmt.Sprint(obj.HostConfig.VolumesFrom), ShouldEqual, fmt.Sprint([]string{"amazeeio-ssh-agent"}))
+		So(fmt.Sprint(obj.HostConfig.VolumesFrom), ShouldEqual, fmt.Sprint([]string{"pygmy-ssh-agent"}))
 	})
 }

--- a/service/ssh/key/ssh_addkey_win.go
+++ b/service/ssh/key/ssh_addkey_win.go
@@ -4,21 +4,23 @@
 package key
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	model "github.com/pygmystack/pygmy/service/interface"
 )
 
 // NewAdder will provide the standard object for the SSH key adder container.
-func NewAdder() model.Service {
+func NewAdder(c *model.Params) model.Service {
 	return model.Service{
 		Config: container.Config{
 			Image: "pygmystack/ssh-agent",
 			Labels: map[string]string{
 				"pygmy.defaults": "true",
 				"pygmy.enable":   "true",
-				"pygmy.name":     "amazeeio-ssh-agent-add-key",
-				"pygmy.network":  "amazeeio-network",
+				"pygmy.name":     fmt.Sprintf("%s-ssh-agent-add-key", c.Prefix),
+				"pygmy.network":  fmt.Sprintf("%s-network", c.Prefix),
 				"pygmy.discrete": "true",
 				"pygmy.output":   "false",
 				"pygmy.purpose":  "addkeys",
@@ -28,7 +30,7 @@ func NewAdder() model.Service {
 		HostConfig: container.HostConfig{
 			IpcMode:     "private",
 			AutoRemove:  false,
-			VolumesFrom: []string{"amazeeio-ssh-agent"},
+			VolumesFrom: []string{fmt.Sprintf("%s-ssh-agent", c.Prefix)},
 		},
 		NetworkConfig: network.NetworkingConfig{},
 	}


### PR DESCRIPTION
I've been asked switch pygmy over to use `pygmy.site` as a default for users, so that's what this done.

It also contributes to the public strategy amazee.io have previously announced where the amazee.io branding is separated from their products - such as Lagoon.

This PR will switch `amazeeio-` container names to `pygmy-` whilst still using existing container names when the network `amazeeio-network` still exists. Custom container names via the `pygmy,name` label are still working as expected and are tested.

I've also added a piece to the readme so that users who need to run applications on `docker.amazee.io` subdomains can do so unhindered - in addition to the dynamic discovery. It would cause me problems as I often use the `clean` command instead of the `down` command - which does in fact delete the docker network.