### PR TITLE
update actions versions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,6 +19,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
       -
         name: System dependencies
         run: sudo apt update && sudo apt install git golang -y || true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: System dependencies
         run: sudo apt update && sudo apt install git golang -y || true
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.17
       -

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -57,6 +57,7 @@ jobs:
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -19,8 +19,8 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           stable: 'false'
           go-version: '1.17'
@@ -42,8 +42,8 @@ jobs:
 #  windows:
 #    runs-on: windows-2019
 #    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions/setup-go@v2
+#      - uses: actions/checkout@v3
+#      - uses: actions/setup-go@v4
 #        with:
 #          stable: 'false'
 #          go-version: '1.16'
@@ -61,8 +61,8 @@ jobs:
     env:
       GO111MODULE: on
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           stable: 'false'
           go-version: '1.17'


### PR DESCRIPTION
A quick PR to update the github actions versions to current latest to hoepfully kill off some of the node12 warnings :crossed_fingers: 

Also set goreleaser to only run the main step on an actual tag, otherwise it was failing on non-tag pushes?