### PR TITLE
Better support built-in image overrides - part 1

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -158,7 +158,7 @@ jobs:
           docker-compose -p drupal9-full exec -T cli composer install;
           sleep 5;
           curl --HEAD http://drupal9-full.docker.amazee.io;
-          curl --HEAD http://drupal9-full.docker.amazee.io | grep "X-LAGOON";
+          curl --HEAD http://drupal9-full.docker.amazee.io | grep -i "x-lagoon";
           ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-full.docker.amazee.io';
           docker-compose -p drupal9-full down;
           docker-compose -p drupal9-full rm;
@@ -171,7 +171,7 @@ jobs:
           docker-compose -p drupal-base exec -T cli composer install;
           sleep 5;
           curl --HEAD http://drupal9-base.docker.amazee.io;
-          curl --HEAD http://drupal9-base.docker.amazee.io | grep "X-LAGOON";
+          curl --HEAD http://drupal9-base.docker.amazee.io | grep -i "x-lagoon";
           ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-base.docker.amazee.io';
           docker-compose -p drupal-base down;
           docker-compose -p drupal-base rm;
@@ -184,7 +184,7 @@ jobs:
           docker-compose -p drupal-postgres exec -T cli composer install;
           sleep 5;
           curl --HEAD http://drupal9-postgres.docker.amazee.io;
-          curl --HEAD http://drupal9-postgres.docker.amazee.io | grep "X-LAGOON";
+          curl --HEAD http://drupal9-postgres.docker.amazee.io | grep -i "x-lagoon";
           ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://drupal9-postgres.docker.amazee.io';
           docker-compose -p drupal-postgres down;
           docker-compose -p drupal-postgres rm;
@@ -196,7 +196,7 @@ jobs:
 #          npm install;
 #          docker-compose -p node up -d;
 #          curl --HEAD http://node.docker.amazee.io;
-#          curl --HEAD http://node.docker.amazee.io | grep "X-LAGOON";
+#          curl --HEAD http://node.docker.amazee.io | grep -i "x-lagoon";
 #          ../../pygmy-linux-amd64 --config ../../examples/pygmy.basic.yml status | grep '\- http://node.docker.amazee.io';
 #          docker-compose -p node down;
 #          docker-compose -p node rm;
@@ -210,7 +210,7 @@ jobs:
           sleep 5;
           curl --HEAD http://ss.docker.amazee.io;
           # Temporarily, we will omit the failure for the X-LAGOON header.;
-          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON" || true;
+          curl --HEAD http://ss.docker.amazee.io | grep -i "x-lagoon" || true;
           docker-compose -p silverstripe-advanced down;
           docker-compose -p silverstripe-advanced rm;
           cd ../../;
@@ -222,7 +222,7 @@ jobs:
           docker-compose -p silverstripe-simple exec -T cli composer install;
           sleep 5;
           curl --HEAD http://ss.docker.amazee.io;
-          curl --HEAD http://ss.docker.amazee.io | grep "X-LAGOON";
+          curl --HEAD http://ss.docker.amazee.io | grep -i "x-lagoon";
           docker-compose -p silverstripe-simple down;
           docker-compose -p silverstripe-simple rm;
           cd ../../;
@@ -233,7 +233,7 @@ jobs:
           lando start || true;
           sleep 5;
           curl --HEAD http://drupal9-base.lndo.site:8000;
-          curl --HEAD http://drupal9-base.lndo.site:8000 | grep "X-Lagoon";
+          curl --HEAD http://drupal9-base.lndo.site:8000 | grep -i "x-lagoon";
           lando destroy -y;
           cd ../../;
 

--- a/service/dnsmasq/dnsmasq_test.go
+++ b/service/dnsmasq/dnsmasq_test.go
@@ -18,7 +18,7 @@ func Test(t *testing.T) {
 	Convey("DNSMasq: Field equality tests...", t, func() {
 		obj := dnsmasq.New(&model.Params{Domain: "docker.amazee.io"})
 
-		So(obj.Config.Image, ShouldEqual, "pygmystack/dnsmasq")
+		So(obj.Config.Image, ShouldContainSubstring, "pygmystack/dnsmasq")
 		So(fmt.Sprint(obj.Config.Cmd), ShouldEqual, fmt.Sprint([]string{"--log-facility=-", "-A", "/docker.amazee.io/127.0.0.1"}))
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")

--- a/service/haproxy/haproxy_test.go
+++ b/service/haproxy/haproxy_test.go
@@ -19,7 +19,7 @@ func Test(t *testing.T) {
 	Convey("HAProxy: Field equality tests...", t, func() {
 		obj := haproxy.New(&model.Params{Domain: "docker.amazee.io"})
 		objPorts := haproxy.NewDefaultPorts()
-		So(obj.Config.Image, ShouldEqual, "pygmystack/haproxy")
+		So(obj.Config.Image, ShouldContainSubstring, "pygmystack/haproxy")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.name"], ShouldEqual, "amazeeio-haproxy")

--- a/service/interface/docker/docker.go
+++ b/service/interface/docker/docker.go
@@ -89,40 +89,42 @@ func DockerPull(image string) (string, error) {
 		// To support image references from external sources to docker.io we need to check
 		// and validate the image reference for all known cases of validity.
 
-		if m, _ := regexp.MatchString("^([a-zA-Z0-9]+[/][a-zA-Z0-9:-_]+[a-zA-Z0-9:-_.]+)$", image); m {
-			// URL was not provided (in full), but the tag was provided.
-			// For this, we prepend 'docker.io/' to the reference.
-			// Examples:
-			//  - amazeeio/pygmy:latest
-			image = fmt.Sprintf("docker.io/%v", image)
-		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9]+[/][a-zA-Z0-9:-]+[a-zA-Z0-9:-_.]+)$", image); m {
-			// URL was not provided (in full), but the tag was not provided.
-			// For this, we prepend 'docker.io/' to the reference.
-			// Examples:
-			//  - amazeeio/pygmy
-			image = fmt.Sprintf("docker.io/%v", image)
-		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9.].+[a-zA-Z0-9]+[/][a-zA-Z0-9:-_]+[a-zA-Z0-9:-_.]+)$", image); m {
+		if m, _ := regexp.MatchString("^(([a-zA-Z0-9._-]+)[/]([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_-]+)[:]([a-zA-Z0-9_-]+))$", image); m {
 			// URL was provided (in full), but the tag was provided.
 			// For this, we do not alter the value provided.
 			// Examples:
-			//  - quay.io/amazeeio/pygmy:latest
-		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9.].+[a-zA-Z0-9]+[/][a-zA-Z0-9:-_]+)$", image); m {
+			//  - quay.io/pygmystack/pygmy:latest
+			image = fmt.Sprintf("%v", image)
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9._-]+)[/]([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_-]+))$", image); m {
 			// URL was provided (in full), but the tag was not provided.
 			// For this, we do not alter the value provided.
 			// Examples:
-			//  - quay.io/amazeeio/pygmy
-		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9]+[:][a-zA-Z0-9.-_]+)$", image); m {
+			//  - quay.io/pygmystack/pygmy
+			image = fmt.Sprintf("%v:latest", image)
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_-]+)[:]([a-zA-Z0-9_-]+))$", image); m {
+			// URL was not provided (in full), but the tag was provided.
+			// For this, we prepend 'docker.io/' to the reference.
+			// Examples:
+			//  - pygmystack/pygmy:latest
+			image = fmt.Sprintf("docker.io/%v", image)
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_-]+))$", image); m {
+			// URL was not provided (in full), but the tag was not provided.
+			// For this, we prepend 'docker.io/' to the reference.
+			// Examples:
+			//  - pygmystack/pygmy
+			image = fmt.Sprintf("docker.io/%v:latest", image)
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[:]([a-zA-Z0-9_-]+))$", image); m {
 			// Library image was provided with tag identifier.
 			// For this, we prepend 'docker.io/' to the reference.
 			// Examples:
 			//  - pygmy:latest
 			image = fmt.Sprintf("docker.io/%v", image)
-		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9-_]+)$", image); m {
+		} else if m, _ := regexp.MatchString("^([a-zA-Z0-9_-]+)$", image); m {
 			// Library image was provided without tag identifier.
 			// For this, we prepend 'docker.io/' to the reference.
 			// Examples:
 			//  - pygmy
-			image = fmt.Sprintf("docker.io/%v", image)
+			image = fmt.Sprintf("docker.io/%v:latest", image)
 		} else {
 			// Validation not successful
 			return "", fmt.Errorf("error: regexp validation for %v failed", image)

--- a/service/mailhog/mailhog_test.go
+++ b/service/mailhog/mailhog_test.go
@@ -20,7 +20,7 @@ func Test(t *testing.T) {
 		obj := mailhog.New(&model.Params{Domain: "docker.amazee.io"})
 		objPorts := mailhog.NewDefaultPorts()
 		So(obj.Config.User, ShouldEqual, "0")
-		So(obj.Config.Image, ShouldEqual, "pygmystack/mailhog")
+		So(obj.Config.Image, ShouldContainSubstring, "pygmystack/mailhog")
 		So(fmt.Sprint(obj.Config.ExposedPorts), ShouldEqual, fmt.Sprint(nat.PortSet{"80/tcp": struct{}{}, "1025/tcp": struct{}{}, "8025/tcp": struct{}{}}))
 		So(fmt.Sprint(obj.Config.Env), ShouldEqual, fmt.Sprint([]string{"MH_UI_BIND_ADDR=0.0.0.0:80", "MH_API_BIND_ADDR=0.0.0.0:80", "AMAZEEIO=AMAZEEIO", "AMAZEEIO_URL=mailhog.docker.amazee.io"}))
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")

--- a/service/ssh/agent/ssh_agent_test.go
+++ b/service/ssh/agent/ssh_agent_test.go
@@ -26,7 +26,7 @@ func TestExampleSearch(t *testing.T) {
 func Test(t *testing.T) {
 	Convey("SSH Agent: Field equality tests...", t, func() {
 		obj := agent.New()
-		So(obj.Config.Image, ShouldEqual, "pygmystack/ssh-agent")
+		So(obj.Config.Image, ShouldContainSubstring, "pygmystack/ssh-agent")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.output"], ShouldEqual, "false")

--- a/service/ssh/key/ssh_addkey_test.go
+++ b/service/ssh/key/ssh_addkey_test.go
@@ -15,7 +15,7 @@ import (
 func TestAdd(t *testing.T) {
 	Convey("SSH Key Adder: Field equality tests...", t, func() {
 		obj := key.NewAdder()
-		So(obj.Config.Image, ShouldEqual, "pygmystack/ssh-agent")
+		So(obj.Config.Image, ShouldContainSubstring, "pygmystack/ssh-agent")
 		So(obj.Config.Labels["pygmy.defaults"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.enable"], ShouldEqual, "true")
 		So(obj.Config.Labels["pygmy.output"], ShouldEqual, "false")


### PR DESCRIPTION
This is the first step towards #458 

This PR:
* loosens the test routines checking for exact image names
* Reorders the DockerPull regex to identify the image reference given
* Support a case insensitive header check (newer haproxy/http2 headers are all lowercase now)

The actual logic to support the image overrides will be done elsewhere (and likely not by me :stuck_out_tongue:) 