### PR TITLE
#505: Cleanup output and provide a json formatter for the status command

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -124,15 +124,14 @@ jobs:
       - name: Test JSON output
         run: |
           ./pygmy-linux-amd64 status --json > pygmy.json
-          cat pygmy.json
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].state' | grep 'running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].image' | grep 'pygmystack/dnsmasq'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].state' | grep 'running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].image' | grep 'ygmystack/haproxy'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].state' | grep 'running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].image' | grep 'pygmystack/mailhog'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].state' | grep 'running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].image' | grep 'pygmystack/ssh-agent'
 
       - name: Test the amazeeio-network for expected results
         run: |

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -124,14 +124,14 @@ jobs:
       - name: Test JSON output
         run: |
           ./pygmy-linux-amd64 status --json > pygmy.json
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].state' | grep -v 'not running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].image' | grep 'pygmystack/dnsmasq'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].state' | grep -v 'not running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].image' | grep 'ygmystack/haproxy'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].state' | grep -v 'not running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].image' | grep 'pygmystack/mailhog'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].state' | grep -v 'not running'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].image' | grep 'pygmystack/ssh-agent'
+          cat pygmy.json | jq '.service_status["amazeeio-dnsmasq"].running' | grep 'true'
+          cat pygmy.json | jq '.service_status["amazeeio-dnsmasq"].image' | grep 'pygmystack/dnsmasq'
+          cat pygmy.json | jq '.service_status["amazeeio-haproxy"].running' | grep 'true'
+          cat pygmy.json | jq '.service_status["amazeeio-haproxy"].image' | grep 'ygmystack/haproxy'
+          cat pygmy.json | jq '.service_status["amazeeio-mailhog"].running' | grep 'true'
+          cat pygmy.json | jq '.service_status["amazeeio-mailhog"].image' | grep 'pygmystack/mailhog'
+          cat pygmy.json | jq '.service_status["amazeeio-ssh-agent"].running' | grep 'true'
+          cat pygmy.json | jq '.service_status["amazeeio-ssh-agent"].image' | grep 'pygmystack/ssh-agent'
 
       - name: Test the amazeeio-network for expected results
         run: |

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -124,13 +124,13 @@ jobs:
       - name: Test JSON output
         run: |
           ./pygmy-linux-amd64 status --json > pygmy.json
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].state' | grep -v 'not running'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].image' | grep 'pygmystack/dnsmasq'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].state' | grep -v 'not running'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].image' | grep 'ygmystack/haproxy'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].state' | grep -v 'not running'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].image' | grep 'pygmystack/mailhog'
-          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].state' | grep -v 'not running'
           cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].image' | grep 'pygmystack/ssh-agent'
 
       - name: Test the amazeeio-network for expected results

--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -121,6 +121,19 @@ jobs:
           grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
           grep "docker.amazee.io" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
 
+      - name: Test JSON output
+        run: |
+          ./pygmy-linux-amd64 status --json > pygmy.json
+          cat pygmy.json
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-dnsmasq"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-haproxy"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-mailhog"].image' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].state' | grep 'running'
+          cat pygmy.json | jq --raw-output '.service_status["amazeeio-ssh-agent"].image' | grep 'running'
+
       - name: Test the amazeeio-network for expected results
         run: |
           docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,7 +135,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		if os.Args[1] != "completion" {
+		if os.Args[1] != "completion" && !jsonOutput {
 			fmt.Println("Using config file:", viper.ConfigFileUsed())
 		}
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,6 +25,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var jsonOutput bool
+
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:     "status",
@@ -34,6 +36,9 @@ var statusCmd = &cobra.Command{
 This includes the docker services, the resolver and SSH key status`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		if jsonOutput {
+			c.JSONFormat = true
+		}
 		library.Status(c)
 
 	},
@@ -42,5 +47,6 @@ This includes the docker services, the resolver and SSH key status`,
 func init() {
 
 	rootCmd.AddCommand(statusCmd)
+	statusCmd.Flags().BoolVarP(&jsonOutput, "json", "", false, "Output status in JSON format")
 
 }

--- a/service/library/dryrun.go
+++ b/service/library/dryrun.go
@@ -37,7 +37,7 @@ func DryRun(c *Config) []CompatibilityCheck {
 							if err != nil {
 								messages = append(messages, CompatibilityCheck{
 									State:   true,
-									Message: fmt.Sprintf("[*] %v is able to start on port %v", name, p),
+									Message: fmt.Sprintf("%v is able to start on port %v", name, p),
 								})
 							} else {
 								conn, err := net.Listen("tcp", ":"+p)
@@ -47,7 +47,7 @@ func DryRun(c *Config) []CompatibilityCheck {
 								if err != nil {
 									messages = append(messages, CompatibilityCheck{
 										State:   false,
-										Message: fmt.Sprintf("[ ] %v is not able to start on port %v: %v", name, p, err),
+										Message: fmt.Sprintf("%v is not able to start on port %v: %v", name, p, err),
 									})
 								}
 							}

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -3,9 +3,8 @@ package library
 
 import (
 	"fmt"
-	"github.com/docker/docker/api/types/volume"
-
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/volume"
 	"github.com/imdario/mergo"
 
 	model "github.com/pygmystack/pygmy/service/interface"
@@ -33,11 +32,33 @@ type Config struct {
 	// NoDefaults will prevent default configuration items.
 	Defaults bool
 
+	// JSONFormat indicates the `status` command should print to stdout in JSON format.
+	JSONFormat bool
+
+	// JSONStatus contains JSON status content.
+	JSONStatus StatusJSON
+
 	// Resolvers is for all resolvers
 	Resolvers []resolv.Resolv `yaml:"resolvers"`
 
 	// Volumes will ensure names volumes are created
 	Volumes map[string]volume.Volume
+}
+
+type StatusJSON struct {
+	PortAvailability []string           `json:"port-availability"`
+	Services         []StatusJSONStatus `json:"service-status"`
+	Networks         []string           `json:"networks"`
+	Resolvers        []string           `json:"resolvers"`
+	Volumes          []string           `json:"volumes"`
+	SSHMessages      []string           `json:"ssh-messages"`
+	URLValidations   []string           `json:"url-validations"`
+}
+
+type StatusJSONStatus struct {
+	Name      string `json:"name"`
+	Container string `json:"container"`
+	State     string `json:"state"`
 }
 
 // Key is a struct with SSH key details.

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -58,7 +58,7 @@ type StatusJSON struct {
 type StatusJSONStatus struct {
 	Container string `json:"container"`
 	ImageRef  string `json:"image"`
-	State     string `json:"state"`
+	State     bool   `json:"running"`
 }
 
 // Key is a struct with SSH key details.

--- a/service/library/library.go
+++ b/service/library/library.go
@@ -46,18 +46,18 @@ type Config struct {
 }
 
 type StatusJSON struct {
-	PortAvailability []string           `json:"port-availability"`
-	Services         []StatusJSONStatus `json:"service-status"`
-	Networks         []string           `json:"networks"`
-	Resolvers        []string           `json:"resolvers"`
-	Volumes          []string           `json:"volumes"`
-	SSHMessages      []string           `json:"ssh-messages"`
-	URLValidations   []string           `json:"url-validations"`
+	PortAvailability []string                    `json:"port_availability"`
+	Services         map[string]StatusJSONStatus `json:"service_status"`
+	Networks         []string                    `json:"networks"`
+	Resolvers        []string                    `json:"resolvers"`
+	Volumes          []string                    `json:"volumes"`
+	SSHMessages      []string                    `json:"ssh_messages"`
+	URLValidations   []string                    `json:"url_validations"`
 }
 
 type StatusJSONStatus struct {
-	Name      string `json:"name"`
 	Container string `json:"container"`
+	ImageRef  string `json:"image"`
 	State     string `json:"state"`
 }
 

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -118,8 +118,17 @@ func Status(c Config) {
 	}
 
 	// List out all running projects to get their URL.
-	containers, _ := docker.DockerContainerList()
 	var urls []string
+
+	for _, Container := range c.Services {
+		Status, _ := Container.Status()
+		url, _ := Container.GetFieldString("url")
+		if url != "" && Status {
+			urls = append(urls, fmt.Sprintf("%s", url))
+		}
+	}
+
+	containers, _ := docker.DockerContainerList()
 	for _, container := range containers {
 		if container.State == "running" && !strings.Contains(fmt.Sprint(container.Names), "amazeeio") {
 			obj, _ := docker.DockerInspect(container.ID)

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -124,7 +124,7 @@ func Status(c Config) {
 		Status, _ := Container.Status()
 		url, _ := Container.GetFieldString("url")
 		if url != "" && Status {
-			urls = append(urls, fmt.Sprintf("%s", url))
+			urls = append(urls, url)
 		}
 	}
 

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -1,12 +1,13 @@
 package library
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/logrusorgru/aurora"
+	"github.com/pygmystack/pygmy/service/color"
 	"strings"
 
-	. "github.com/logrusorgru/aurora"
-
-	"github.com/pygmystack/pygmy/service/color"
+	_ "github.com/logrusorgru/aurora"
 	"github.com/pygmystack/pygmy/service/endpoint"
 	model "github.com/pygmystack/pygmy/service/interface"
 	"github.com/pygmystack/pygmy/service/interface/docker"
@@ -15,20 +16,14 @@ import (
 
 // Status will show the state of all the things Pygmy manages.
 func Status(c Config) {
-
 	Setup(&c)
 	checks := DryRun(&c)
 	agentPresent := false
 
 	if len(checks) > 0 {
 		for _, check := range checks {
-			if check.State {
-				color.Print(Green(check.Message + "\n"))
-			} else {
-				color.Print(Red(check.Message + "\n"))
-			}
+			c.JSONStatus.PortAvailability = append(c.JSONStatus.PortAvailability, check.Message)
 		}
-		fmt.Println()
 	}
 
 	Containers, _ := docker.DockerContainerList()
@@ -45,10 +40,16 @@ func Status(c Config) {
 						agentPresent = true
 					}
 					if enabled && !discrete && name != "" {
+						st := StatusJSONStatus{
+							Name:      name,
+							Container: name,
+						}
 						if s, _ := Service.Status(); s {
-							color.Print(Green(fmt.Sprintf("[*] %s: Running as container %s\n", name, name)))
+							st.State = "running"
+							c.JSONStatus.Services = append(c.JSONStatus.Services, st)
 						} else {
-							color.Print(Red(fmt.Sprintf("[ ] %s is not running\n", name)))
+							st.State = "not running"
+							c.JSONStatus.Services = append(c.JSONStatus.Services, st)
 						}
 					}
 				}
@@ -61,7 +62,12 @@ func Status(c Config) {
 			name, _ := Service.GetFieldString("name")
 			discrete, _ := Service.GetFieldBool("discrete")
 			if !discrete {
-				color.Print(Red(fmt.Sprintf("[ ] %s is not running\n", name)))
+				st := StatusJSONStatus{
+					Name:      name,
+					Container: name,
+					State:     "not running",
+				}
+				c.JSONStatus.Services = append(c.JSONStatus.Services, st)
 			}
 		}
 	}
@@ -69,9 +75,9 @@ func Status(c Config) {
 	for _, Network := range c.Networks {
 		for _, Container := range Network.Containers {
 			if x, _ := docker.DockerNetworkConnected(Network.Name, Container.Name); !x {
-				color.Print(Red(fmt.Sprintf("[ ] %s is not connected to network %s\n", Container.Name, Network.Name)))
+				c.JSONStatus.Networks = append(c.JSONStatus.Networks, fmt.Sprintf("%s is not connected to the network %s", Container.Name, Network.Name))
 			} else {
-				color.Print(Green(fmt.Sprintf("[*] %s is connected to network %s\n", Container.Name, Network.Name)))
+				c.JSONStatus.Networks = append(c.JSONStatus.Networks, fmt.Sprintf("%s is connected to the network %s", Container.Name, Network.Name))
 			}
 		}
 	}
@@ -79,17 +85,17 @@ func Status(c Config) {
 	for _, resolver := range c.Resolvers {
 		r := resolv.Resolv{Name: resolver.Name, Data: resolver.Data, Folder: resolver.Folder, File: resolver.File}
 		if s := r.Status(&model.Params{Domain: c.Domain}); s {
-			color.Print(Green(fmt.Sprintf("[*] Resolv %v is properly connected\n", resolver.Name)))
+			c.JSONStatus.Resolvers = append(c.JSONStatus.Resolvers, fmt.Sprintf("Resolv %s is properly connected", resolver.Name))
 		} else {
-			color.Print(Red(fmt.Sprintf("[ ] Resolv %v is not properly connected\n", resolver.Name)))
+			c.JSONStatus.Resolvers = append(c.JSONStatus.Resolvers, fmt.Sprintf("Resolv %s is not properly connected", resolver.Name))
 		}
 	}
 
 	for _, volume := range c.Volumes {
 		if s, _ := docker.DockerVolumeExists(volume.Name); s {
-			color.Print(Green(fmt.Sprintf("[*] Volume %s has been created\n", volume.Name)))
+			c.JSONStatus.Volumes = append(c.JSONStatus.Volumes, fmt.Sprintf("Volume %s has been created", volume.Name))
 		} else {
-			color.Print(Green(fmt.Sprintf("[ ] Volume %s has not ben created\n", volume.Name)))
+			c.JSONStatus.Volumes = append(c.JSONStatus.Volumes, fmt.Sprintf("Volume %s has not been created", volume.Name))
 		}
 	}
 
@@ -99,8 +105,11 @@ func Status(c Config) {
 			purpose, _ := v.GetFieldString("purpose")
 			if purpose == "sshagent" {
 				l, _ := docker.DockerExec(v.Config.Labels["pygmy.name"], "ssh-add -l")
-				output := strings.Trim(string(l), "\n")
-				fmt.Println(output)
+				// Remove \u0000 & \u0001 from output messages.
+				output := strings.ReplaceAll(string(l), "\u0000", "")
+				output = strings.ReplaceAll(output, "\u0001", "")
+				output = strings.Trim(output, "\n")
+				c.JSONStatus.SSHMessages = append(c.JSONStatus.SSHMessages, fmt.Sprintf("%s", output))
 			}
 		}
 	}
@@ -112,9 +121,9 @@ func Status(c Config) {
 		if url != "" && Status {
 			endpoint.Validate(url)
 			if r := endpoint.Validate(url); r {
-				fmt.Printf(" - %v (%v)\n", url, name)
+				c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" - %s (%s)", url, name))
 			} else {
-				fmt.Printf(" ! %v (%v)\n", url, name)
+				c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" ! %s (%s)", url, name))
 			}
 		}
 	}
@@ -139,14 +148,67 @@ func Status(c Config) {
 		}
 	}
 
-	cleanurls := unique(urls)
-	for _, url := range cleanurls {
-		endpoint.Validate(url)
-		if r := endpoint.Validate(url); r {
-			fmt.Printf(" - %v\n", url)
+	if c.JSONFormat {
+		PrintStatusJSON(c)
+		return
+	}
+
+	PrintStatusHumanReadable(c)
+
+}
+
+func PrintStatusJSON(c Config) {
+	jsonData, _ := json.Marshal(c.JSONStatus)
+	fmt.Println(string(jsonData))
+
+}
+func PrintStatusHumanReadable(c Config) {
+	for _, v := range c.JSONStatus.PortAvailability {
+		if strings.Contains(v, "is not able to start on port") {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s\n", v)))
 		} else {
-			fmt.Printf(" ! %v\n", url)
+			color.Print(aurora.Green(fmt.Sprintf("[*] %s\n", v)))
 		}
+	}
+
+	for _, v := range c.JSONStatus.Services {
+		if strings.Contains(v.State, "not running") {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s is not running\n", v.Name)))
+		} else {
+			color.Print(aurora.Green(fmt.Sprintf("[*] %s: Running as container %s\n", v.Name, v.Container)))
+		}
+	}
+
+	for _, v := range c.JSONStatus.Resolvers {
+		if strings.Contains(v, "not properly connected") {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s\n", v)))
+		} else {
+			color.Print(aurora.Green(fmt.Sprintf("[*] %s\n", v)))
+		}
+	}
+
+	for _, v := range c.JSONStatus.Networks {
+		if strings.Contains(v, "is not connected to network") {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s\n", v)))
+		} else {
+			color.Print(aurora.Green(fmt.Sprintf("[*] %s\n", v)))
+		}
+	}
+
+	for _, v := range c.JSONStatus.Volumes {
+		if strings.Contains(v, "has not been created") {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s\n", v)))
+		} else {
+			color.Print(aurora.Green(fmt.Sprintf("[*] %s\n", v)))
+		}
+	}
+
+	for _, v := range c.JSONStatus.SSHMessages {
+		fmt.Printf("%s\n", v)
+	}
+
+	for _, v := range c.JSONStatus.URLValidations {
+		fmt.Printf("%s\n", v)
 	}
 
 }

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -46,13 +46,12 @@ func Status(c Config) {
 							c.JSONStatus.Services[name] = StatusJSONStatus{
 								Container: name,
 								ImageRef:  Service.Image,
-								State:     "running",
+								State:     true,
 							}
 						} else {
 							c.JSONStatus.Services[name] = StatusJSONStatus{
 								Container: name,
 								ImageRef:  Service.Image,
-								State:     "not running",
 							}
 						}
 					}
@@ -69,7 +68,6 @@ func Status(c Config) {
 				c.JSONStatus.Services[name] = StatusJSONStatus{
 					Container: name,
 					ImageRef:  Service.Image,
-					State:     "not running",
 				}
 			}
 		}
@@ -180,10 +178,10 @@ func PrintStatusHumanReadable(c Config) {
 	}
 
 	for k, v := range c.JSONStatus.Services {
-		if strings.Contains(v.State, "not running") {
-			color.Print(aurora.Red(fmt.Sprintf("[ ] %s is not running\n", k)))
-		} else {
+		if v.State {
 			color.Print(aurora.Green(fmt.Sprintf("[*] %s: Running as container %s\n", k, v.Container)))
+		} else {
+			color.Print(aurora.Red(fmt.Sprintf("[ ] %s is not running\n", k)))
 		}
 	}
 

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -4,10 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/logrusorgru/aurora"
-	"github.com/pygmystack/pygmy/service/color"
 	"strings"
 
-	_ "github.com/logrusorgru/aurora"
+	"github.com/pygmystack/pygmy/service/color"
 	"github.com/pygmystack/pygmy/service/endpoint"
 	model "github.com/pygmystack/pygmy/service/interface"
 	"github.com/pygmystack/pygmy/service/interface/docker"

--- a/service/library/status.go
+++ b/service/library/status.go
@@ -108,21 +108,7 @@ func Status(c Config) {
 				output := strings.ReplaceAll(string(l), "\u0000", "")
 				output = strings.ReplaceAll(output, "\u0001", "")
 				output = strings.Trim(output, "\n")
-				c.JSONStatus.SSHMessages = append(c.JSONStatus.SSHMessages, fmt.Sprintf("%s", output))
-			}
-		}
-	}
-
-	for _, Container := range c.Services {
-		Status, _ := Container.Status()
-		name, _ := Container.GetFieldString("name")
-		url, _ := Container.GetFieldString("url")
-		if url != "" && Status {
-			endpoint.Validate(url)
-			if r := endpoint.Validate(url); r {
-				c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" - %s (%s)", url, name))
-			} else {
-				c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" ! %s (%s)", url, name))
+				c.JSONStatus.SSHMessages = append(c.JSONStatus.SSHMessages, output)
 			}
 		}
 	}
@@ -144,6 +130,16 @@ func Status(c Config) {
 					urls = append(urls, url)
 				}
 			}
+		}
+	}
+
+	cleanurls := unique(urls)
+	for _, url := range cleanurls {
+		endpoint.Validate(url)
+		if r := endpoint.Validate(url); !r {
+			c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" ! %v\n", url))
+		} else {
+			c.JSONStatus.URLValidations = append(c.JSONStatus.URLValidations, fmt.Sprintf(" - %v\n", url))
 		}
 	}
 


### PR DESCRIPTION
Proposed solution to #505.

Thank you for reaching out @sonnykt & @AlexSkrypnyk - I would love some feedback on this one if you can spare the chance. I'll give it some time and merge but if you have any feedback now is the _best_ time to provide it.

This change is to better support the script-ability of the status command for people that are using this in automation.

## Changes

- Adds a JSON formatter for the status command.
- Removes special characters `\u0000` and `\u0001` from the output of SSH container log messages.

## Future

This change opens up the gate for other commands to return json output - so if this is of interest to you just open a ticket.

## Output examples for feedback

### JSON Formatted

```json
~/GolandProjects/pygmy $ go run main.go status --json | jq
{
  "port_availability": [
    "amazeeio-dnsmasq is able to start on port 6053",
    "amazeeio-mailhog is able to start on port 1025",
    "amazeeio-haproxy is able to start on port 80",
    "amazeeio-haproxy is able to start on port 443"
  ],
  "service_status": {
    "amazeeio-dnsmasq": {
      "container": "amazeeio-dnsmasq",
      "image": "ghcr.io/pygmystack/dnsmasq:pr-2",
      "state": "not running"
    },
    "amazeeio-haproxy": {
      "container": "amazeeio-haproxy",
      "image": "ghcr.io/pygmystack/haproxy:pr-12",
      "state": "not running"
    },
    "amazeeio-mailhog": {
      "container": "amazeeio-mailhog",
      "image": "ghcr.io/pygmystack/mailhog:pr-3",
      "state": "not running"
    },
    "amazeeio-ssh-agent": {
      "container": "amazeeio-ssh-agent",
      "image": "ghcr.io/pygmystack/ssh-agent:pr-2",
      "state": "not running"
    }
  },
  "networks": null,
  "resolvers": [
    "Resolv Linux Resolver is not properly connected"
  ],
  "volumes": null,
  "ssh_messages": null,
  "url_validations": null
}
```

```json
~/GolandProjects/pygmy $ go run main.go status --json | jq
{
  "port_availability": null,
  "service_status": {
    "amazeeio-dnsmasq": {
      "container": "amazeeio-dnsmasq",
      "image": "ghcr.io/pygmystack/dnsmasq:pr-2",
      "state": "running"
    },
    "amazeeio-haproxy": {
      "container": "amazeeio-haproxy",
      "image": "ghcr.io/pygmystack/haproxy:pr-12",
      "state": "running"
    },
    "amazeeio-mailhog": {
      "container": "amazeeio-mailhog",
      "image": "ghcr.io/pygmystack/mailhog:pr-3",
      "state": "running"
    },
    "amazeeio-ssh-agent": {
      "container": "amazeeio-ssh-agent",
      "image": "ghcr.io/pygmystack/ssh-agent:pr-2",
      "state": "running"
    }
  },
  "networks": null,
  "resolvers": [
    "Resolv Linux Resolver is properly connected"
  ],
  "volumes": null,
  "ssh_messages": [
    "U4096 SHA256:hc7fU47+m7ABUTvCNpr4Kbf236ZKVpQ5oId2Hx3A/kk /home/karl/.ssh/id_rsa (RSA)"
  ],
  "url_validations": [
    " - http://mailhog.docker.amazee.io\n",
    " - http://docker.amazee.io/stats\n"
  ]
}
```

### Without JSON formatter

```
~/GolandProjects/pygmy $ go run main.go status            
Using config file: /home/karl/.pygmy.yml
[*] amazeeio-dnsmasq is able to start on port 6053
[*] amazeeio-mailhog is able to start on port 1025
[*] amazeeio-haproxy is able to start on port 80
[*] amazeeio-haproxy is able to start on port 443
[ ] amazeeio-mailhog is not running
[ ] amazeeio-haproxy is not running
[ ] amazeeio-ssh-agent is not running
[ ] amazeeio-dnsmasq is not running
[ ] Resolv Linux Resolver is not properly connected
```

```
~/GolandProjects/pygmy $ go run main.go status
Using config file: /home/karl/.pygmy.yml
[*] amazeeio-mailhog: Running as container amazeeio-mailhog
[*] amazeeio-haproxy: Running as container amazeeio-haproxy
[*] amazeeio-dnsmasq: Running as container amazeeio-dnsmasq
[*] amazeeio-ssh-agent: Running as container amazeeio-ssh-agent
[*] Resolv Linux Resolver is properly connected
U4096 SHA256:hc7fU47+m7ABUTvCNpr4Kbf236ZKVpQ5oId2Hx3A/kk /home/karl/.ssh/id_rsa (RSA)
 - http://mailhog.docker.amazee.io
 - http://docker.amazee.io/stats
```