### PR TITLE
chore: use main branch service images for tests

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -167,10 +167,10 @@ jobs:
           echo "Starting...";
           ./pygmy-linux-amd64 --config examples/pygmy.overrides.yml up;
           echo "Checking image references in started containers...";
-          docker container inspect amazeeio-dnsmasq   | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/dnsmasq";
-          docker container inspect amazeeio-haproxy   | jq '.[].Config.Image' | grep 'ghcr.io/pygmystack/haproxy';
-          docker container inspect amazeeio-mailhog   | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/mailhog";
-          docker container inspect amazeeio-ssh-agent | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/ssh-agent";
+          docker container inspect amazeeio-dnsmasq   | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/dnsmasq:main";
+          docker container inspect amazeeio-haproxy   | jq '.[].Config.Image' | grep 'ghcr.io/pygmystack/haproxy:main';
+          docker container inspect amazeeio-mailhog   | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/mailhog:main";
+          docker container inspect amazeeio-ssh-agent | jq '.[].Config.Image' | grep "ghcr.io/pygmystack/ssh-agent:main";
           echo "Cleaning...";
           ./pygmy-linux-amd64 clean
           echo "Starting...";

--- a/examples/pygmy.overrides.yml
+++ b/examples/pygmy.overrides.yml
@@ -1,10 +1,10 @@
 ---
 services:
   amazeeio-haproxy:
-    image: ghcr.io/pygmystack/haproxy
+    image: ghcr.io/pygmystack/haproxy:main
   amazeeio-ssh-agent:
-    image: ghcr.io/pygmystack/ssh-agent
+    image: ghcr.io/pygmystack/ssh-agent:main
   amazeeio-dnsmasq:
-    image: ghcr.io/pygmystack/dnsmasq
+    image: ghcr.io/pygmystack/dnsmasq:main
   amazeeio-mailhog:
-    image: ghcr.io/pygmystack/mailhog
+    image: ghcr.io/pygmystack/mailhog:main


### PR DESCRIPTION
With the changes in #462 we can now provide override images to a pygmy config.

This PR just uses the current main branch images for the services, as a method of ensuring they (instead of latest) build.