### PR TITLE
Fix-dockerpull-regex

### DIFF
--- a/service/interface/docker/docker.go
+++ b/service/interface/docker/docker.go
@@ -90,31 +90,31 @@ func DockerPull(image string) (string, error) {
 		// To support image references from external sources to docker.io we need to check
 		// and validate the image reference for all known cases of validity.
 
-		if m, _ := regexp.MatchString("^(([a-zA-Z0-9._-]+)[/]([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_.-]+)[:]([a-zA-Z0-9_-]+))$", image); m {
+		if m, _ := regexp.MatchString("^(([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+)[:]([a-zA-Z0-9_.-]+))$", image); m {
 			// URL was provided (in full), but the tag was provided.
 			// For this, we do not alter the value provided.
 			// Examples:
 			//  - quay.io/pygmystack/pygmy:latest
 			image = fmt.Sprintf("%v", image)
-		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9._-]+)[/]([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_-]+))$", image); m {
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+))$", image); m {
 			// URL was provided (in full), but the tag was not provided.
 			// For this, we do not alter the value provided.
 			// Examples:
 			//  - quay.io/pygmystack/pygmy
 			image = fmt.Sprintf("%v:latest", image)
-		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_.-]+)[:]([a-zA-Z0-9_-]+))$", image); m {
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+)[:]([a-zA-Z0-9_.-]+))$", image); m {
 			// URL was not provided (in full), but the tag was provided.
 			// For this, we prepend 'docker.io/' to the reference.
 			// Examples:
 			//  - pygmystack/pygmy:latest
 			image = fmt.Sprintf("docker.io/%v", image)
-		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[/]([a-zA-Z0-9_.-]+))$", image); m {
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_.-]+)[/]([a-zA-Z0-9_.-]+))$", image); m {
 			// URL was not provided (in full), but the tag was not provided.
 			// For this, we prepend 'docker.io/' to the reference.
 			// Examples:
 			//  - pygmystack/pygmy
 			image = fmt.Sprintf("docker.io/%v:latest", image)
-		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_-]+)[:]([a-zA-Z0-9_.-]+))$", image); m {
+		} else if m, _ := regexp.MatchString("^(([a-zA-Z0-9_.-]+)[:]([a-zA-Z0-9_.-]+))$", image); m {
 			// Library image was provided with tag identifier.
 			// For this, we prepend 'docker.io/' to the reference.
 			// Examples:

--- a/service/library/update.go
+++ b/service/library/update.go
@@ -25,6 +25,8 @@ func Update(c Config) {
 			result, err = docker.DockerPull(service.Config.Image)
 			if err == nil {
 				fmt.Println(result)
+			} else {
+				fmt.Println(err)
 			}
 		}
 


### PR DESCRIPTION
In #462 we introduced expanded regex to support pulling of more images inside Pygmy, with all manner of fallbacks for partial image refs:

<<registry>>/<<organization>>/<<name>>:<<tag>>

However, yours truly managed to miss a couple of cases in the regex, namely:
* tags with periods in (d'oh)
* image names with periods in (it's actually valid)
* organizations with periods in them (it may happen)

Reference: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests

This PR adds support for those edge cases into the regex, and also adds a helpful error message return for when `pygmy pull` fails - most likely for a missing image, or bad regex

Closes #536