### PR TITLE
Remove Portainer from tests

### DIFF
--- a/.github/workflows/pygmy.yml
+++ b/.github/workflows/pygmy.yml
@@ -155,7 +155,6 @@ jobs:
           docker network inspect amazeeio-network | jq '.[].Name' | grep "amazeeio-network";
           docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-haproxy";
           docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-mailhog";
-          docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].Name' | grep "amazeeio-portainer";
           docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address';
           docker network inspect amazeeio-network | jq '.[].Containers' | jq '.[].IPv4Address' | grep "10.99.99.";
 
@@ -167,9 +166,6 @@ jobs:
           docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
           docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-haproxy   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
-          docker inspect amazeeio-portainer | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
           docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.hocuspocus"]'  | grep "42";
           docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.abracadabra"]' | grep "1";
           docker inspect amazeeio-ssh-agent | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";

--- a/examples/pygmy.basic.yml
+++ b/examples/pygmy.basic.yml
@@ -33,34 +33,6 @@ services:
       Labels:
         - pygmy.enable: false
 
-  amazeeio-portainer:
-    Config:
-      Image: portainer/portainer
-      Env:
-        - "AMAZEEIO=AMAZEEIO"
-        - "AMAZEEIO_URL=portainer.docker.amazee.io"
-        - "AMAZEEIO_HTTP_PORT=9000"
-      Labels:
-        - pygmy.enable: true
-        - pygmy.name: amazeeio-portainer
-        - pygmy.network: amazeeio-network
-        - pygmy.weight: 23
-        - pygmy.url: http://portainer.docker.amazee.io
-        - pygmy.hocuspocus: 42
-        - pygmy.abracadabra: true
-        - pygmy.opensesame: correct
-      ExposedPorts:
-        9000/tcp: {}
-    HostConfig:
-      Binds:
-        - /var/run/docker.sock:/var/run/docker.sock
-        - portainer_data:/data
-      PortBindings:
-        8000/tcp:
-          - HostPort: 8200
-        9000/tcp:
-          - HostPort: 8100
-
   pygmy-cowsay:
     Config:
       Image: mbentley/cowsay
@@ -75,7 +47,3 @@ services:
         - pygmy.weight: 99
     HostConfig:
       AutoRemove: true
-
-volumes:
-  portainer_data:
-    Name: portainer_data

--- a/examples/pygmy.complex.yml
+++ b/examples/pygmy.complex.yml
@@ -41,29 +41,6 @@ services:
         80/tcp:
           - HostPort: 8770
 
-  unofficial-portainer:
-    Config:
-      Image: portainer/portainer
-      Labels:
-        - pygmy.enable: true
-        - pygmy.name: unofficial-portainer
-        - pygmy.network: amazeeio-network
-        - pygmy.url: http://portainer.docker.amazee.io
-        - traefik.enable: true
-        - traefik.port: 80
-        - traefik.http.routers.portainer.rule: Host(`portainer.docker.amazee.io`)
-      ExposedPorts:
-        9000/tcp: {}
-    HostConfig:
-      Binds:
-        - /var/run/docker.sock:/var/run/docker.sock
-        - portainer_data:/data
-      PortBindings:
-        8000/tcp:
-          - HostPort: 8200
-        9000/tcp:
-          - HostPort: 8100
-
   unofficial-traefik-2:
     Config:
       Image: library/traefik:v2.1.3
@@ -123,8 +100,4 @@ networks:
       - pygmy.network: amazeeio-network
 
 resolvers: []
-
-volumes:
-  portainer_data:
-    Name: portainer_data
 

--- a/main_test.go
+++ b/main_test.go
@@ -200,10 +200,10 @@ func TestCustom(t *testing.T) {
 	configuration := &config{
 		name:               "custom",
 		configpath:         "/examples/pygmy.complex.yml",
-		endpoints:          []string{"http://traefik.docker.amazee.io", "http://mailhog.docker.amazee.io", "http://portainer.docker.amazee.io", "http://phpmyadmin.docker.amazee.io"},
-		images:             []string{"pygmystack/ssh-agent", "pygmystack/mailhog", "phpmyadmin/phpmyadmin", "portainer/portainer", "library/traefik:v2.1.3"},
-		services:           []string{"unofficial-portainer", "unofficial-traefik-2", "unofficial-phpmyadmin", "amazeeio-mailhog"},
-		servicewithports:   []string{"amazeeio-mailhog", "unofficial-portainer", "unofficial-phpmyadmin", "unofficial-traefik-2"},
+		endpoints:          []string{"http://traefik.docker.amazee.io", "http://mailhog.docker.amazee.io", "http://phpmyadmin.docker.amazee.io"},
+		images:             []string{"pygmystack/ssh-agent", "pygmystack/mailhog", "phpmyadmin/phpmyadmin", "library/traefik:v2.1.3"},
+		services:           []string{"unofficial-traefik-2", "unofficial-phpmyadmin", "amazeeio-mailhog"},
+		servicewithports:   []string{"amazeeio-mailhog", "unofficial-phpmyadmin", "unofficial-traefik-2"},
 		skipendpointchecks: false,
 	}
 	setup(t, configuration)


### PR DESCRIPTION
The `portainer/portainer` image no longer exists, so it has to go.

[source](https://hub.docker.com/r/portainer/portainer)