### PR TITLE
Fix incorrect YAML key configuration in documentation

### DIFF
--- a/docs/customisation/introduction.md
+++ b/docs/customisation/introduction.md
@@ -103,8 +103,8 @@ volumes: []
 
 # keys is all of the SSH key paths which you're utilising.
 keys:
-  - Path: /home/user1/.ssh/id_rsa
-  - Path: /home/user2/.ssh/id_rsa
+  - path: /home/user1/.ssh/id_rsa
+  - path: /home/user2/.ssh/id_rsa
 ```
 
 ## Applied examples

--- a/docs/customisation/introduction.md
+++ b/docs/customisation/introduction.md
@@ -103,8 +103,8 @@ volumes: []
 
 # keys is all of the SSH key paths which you're utilising.
 keys:
-  - /home/user1/.ssh/id_rsa
-  - /home/user2/.ssh/id_rsa
+  - Path: /home/user1/.ssh/id_rsa
+  - Path: /home/user2/.ssh/id_rsa
 ```
 
 ## Applied examples


### PR DESCRIPTION
### Summary
This PR fixes the incorrect example of key configuration in the pygmy YAML documentation (`~/.pygmy.yml`).

### Changes
- Updated the `keys` section to use the correct `Path` key for specifying SSH keys.

### Reason
The current documentation incorrectly lists `keys` as a list of strings, which leads to errors like:
```
2 error(s) decoding:

'Keys[0]' expected a map, got 'string'
'Keys[1]' expected a map, got 'string'
```

