### PR TITLE
hotfix: restart haproxy before validating enpoints

### DIFF
--- a/external/docker/commands/up.go
+++ b/external/docker/commands/up.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	. "github.com/logrusorgru/aurora"
+	"github.com/docker/docker/api/types/container"
 
 	"github.com/pygmystack/pygmy/external/docker/setup"
 	"github.com/pygmystack/pygmy/internal/runtime/docker"
@@ -15,6 +16,7 @@ import (
 	"github.com/pygmystack/pygmy/internal/runtime/docker/internals/volumes"
 	"github.com/pygmystack/pygmy/internal/utils/color"
 	"github.com/pygmystack/pygmy/internal/utils/endpoint"
+
 )
 
 // Up will bring Pygmy up.
@@ -141,6 +143,19 @@ func Up(c setup.Config) error {
 			}
 		}
 	}
+
+	// ------------------------------------------------------------------------
+	// Restart the haproxy container.
+	// This is an intermin fix that for some reason solves
+	// https://github.com/pygmystack/pygmy/issues/644
+	haproxyContainer := "amazeeio-haproxy"
+	opts := container.StopOptions{}
+    
+	if err := cli.ContainerRestart(ctx, haproxyContainer, opts); err != nil {
+		color.Print(Red(fmt.Sprintf("Failed to restart %s: %v\n", haproxyContainer, err)))
+	} 
+	// -------------------------------------------------------------------------
+
 
 	for _, service := range c.Services {
 		name, _ := service.GetFieldString(ctx, cli, "name")

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/pygmystack/pygmy
 
-go 1.21.0
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.3
 
 require (
 	github.com/containerd/platforms v0.2.1


### PR DESCRIPTION
An interim hotfix that attempts to resolve #644 

This change restarts the haproxy container after `pygmy up` creates all the containers, which fixes haproxy not working and hanging on any http requests to it.